### PR TITLE
[FEAT]: Supabase config, scheams, controllers and bucket files. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.*
 
 # local env files
 .env*.local
+.env
 
 # typescript
 *.tsbuildinfo

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ yarn-error.*
 
 app-example
 
+# IDE
+.idea/
+
 # generated native folders
 /ios
 /android

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml

--- a/.idea/caches/deviceStreaming.xml
+++ b/.idea/caches/deviceStreaming.xml
@@ -440,6 +440,18 @@
           <option name="screenY" value="1600" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="google" />
+          <option name="codename" value="frankel" />
+          <option name="id" value="frankel" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Frankel" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2424" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
           <option name="codename" value="g0q" />
@@ -656,6 +668,18 @@
           <option name="screenDensity" value="280" />
           <option name="screenX" value="720" />
           <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="google" />
+          <option name="codename" value="mustang" />
+          <option name="id" value="mustang" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 10 Pro XL" />
+          <option name="screenDensity" value="390" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2404" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />

--- a/.idea/caches/deviceStreaming.xml
+++ b/.idea/caches/deviceStreaming.xml
@@ -1,0 +1,848 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceStreaming">
+    <option name="deviceSelectionList">
+      <list>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="Sony" />
+          <option name="codename" value="A402SO" />
+          <option name="id" value="A402SO" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Sony" />
+          <option name="name" value="Xperia 10" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2520" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="27" />
+          <option name="brand" value="DOCOMO" />
+          <option name="codename" value="F01L" />
+          <option name="id" value="F01L" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="FUJITSU" />
+          <option name="name" value="F-01L" />
+          <option name="screenDensity" value="360" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1280" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="OnePlus" />
+          <option name="codename" value="OP535DL1" />
+          <option name="id" value="OP535DL1" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="OnePlus" />
+          <option name="name" value="CPH2409" />
+          <option name="screenDensity" value="401" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2412" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="OnePlus" />
+          <option name="codename" value="OP5552L1" />
+          <option name="id" value="OP5552L1" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="OnePlus" />
+          <option name="name" value="CPH2415" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2412" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="OnePlus" />
+          <option name="codename" value="OP5552L1" />
+          <option name="id" value="OP5552L1" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="OnePlus" />
+          <option name="name" value="CPH2415" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2412" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="OPPO" />
+          <option name="codename" value="OP573DL1" />
+          <option name="id" value="OP573DL1" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="OPPO" />
+          <option name="name" value="CPH2557" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="28" />
+          <option name="brand" value="DOCOMO" />
+          <option name="codename" value="SH-01L" />
+          <option name="id" value="SH-01L" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="SHARP" />
+          <option name="name" value="AQUOS sense2 SH-01L" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2160" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a14m" />
+          <option name="id" value="a14m" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-A145R" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2408" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a15" />
+          <option name="id" value="a15" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="A15" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a15x" />
+          <option name="id" value="a15x" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="A15 5G" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a16x" />
+          <option name="id" value="a16x" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="A16 5G" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a35x" />
+          <option name="id" value="a35x" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="A35" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="akita" />
+          <option name="id" value="akita" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 8a" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="google" />
+          <option name="codename" value="akita" />
+          <option name="id" value="akita" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 8a" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="arcfox" />
+          <option name="id" value="arcfox" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="razr plus 2024" />
+          <option name="screenDensity" value="360" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="1272" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="austin" />
+          <option name="id" value="austin" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto g 5G (2022)" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="b0q" />
+          <option name="id" value="b0q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S22 Ultra" />
+          <option name="screenDensity" value="600" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3088" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="b6q" />
+          <option name="id" value="b6q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Flip 6" />
+          <option name="screenDensity" value="340" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2640" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="32" />
+          <option name="brand" value="google" />
+          <option name="codename" value="bluejay" />
+          <option name="id" value="bluejay" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 6a" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="caiman" />
+          <option name="id" value="caiman" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9 Pro" />
+          <option name="screenDensity" value="360" />
+          <option name="screenX" value="960" />
+          <option name="screenY" value="2142" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="google" />
+          <option name="codename" value="caiman" />
+          <option name="id" value="caiman" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9 Pro" />
+          <option name="screenDensity" value="360" />
+          <option name="screenX" value="960" />
+          <option name="screenY" value="2142" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="comet" />
+          <option name="default" value="true" />
+          <option name="id" value="comet" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9 Pro Fold" />
+          <option name="screenDensity" value="390" />
+          <option name="screenX" value="2076" />
+          <option name="screenY" value="2152" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="google" />
+          <option name="codename" value="comet" />
+          <option name="default" value="true" />
+          <option name="id" value="comet" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9 Pro Fold" />
+          <option name="screenDensity" value="390" />
+          <option name="screenX" value="2076" />
+          <option name="screenY" value="2152" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="29" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="crownqlteue" />
+          <option name="id" value="crownqlteue" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Note9" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="2220" />
+          <option name="screenY" value="1080" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="dm2q" />
+          <option name="id" value="dm2q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="S23 Plus" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="dm3q" />
+          <option name="id" value="dm3q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S23 Ultra" />
+          <option name="screenDensity" value="600" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3088" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="dubai" />
+          <option name="id" value="dubai" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="edge 30" />
+          <option name="screenDensity" value="405" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="e1q" />
+          <option name="default" value="true" />
+          <option name="id" value="e1q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S24" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="e3q" />
+          <option name="id" value="e3q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S24 Ultra" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3120" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="google" />
+          <option name="codename" value="eos" />
+          <option name="id" value="eos" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Eos" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="384" />
+          <option name="screenY" value="384" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="google" />
+          <option name="codename" value="felix" />
+          <option name="id" value="felix" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel Fold" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="2208" />
+          <option name="screenY" value="1840" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="felix" />
+          <option name="id" value="felix" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel Fold" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="2208" />
+          <option name="screenY" value="1840" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="google" />
+          <option name="codename" value="felix_camera" />
+          <option name="id" value="felix_camera" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel Fold (Camera-enabled)" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="2208" />
+          <option name="screenY" value="1840" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="fogona" />
+          <option name="id" value="fogona" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto g play - 2024" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="fogos" />
+          <option name="id" value="fogos" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto g34 5G" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="g0q" />
+          <option name="id" value="g0q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-S906U1" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="gta9pwifi" />
+          <option name="id" value="gta9pwifi" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-X210" />
+          <option name="screenDensity" value="240" />
+          <option name="screenX" value="1200" />
+          <option name="screenY" value="1920" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="gts7lwifi" />
+          <option name="id" value="gts7lwifi" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-T870" />
+          <option name="screenDensity" value="340" />
+          <option name="screenX" value="1600" />
+          <option name="screenY" value="2560" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="gts7xllite" />
+          <option name="id" value="gts7xllite" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-T738U" />
+          <option name="screenDensity" value="340" />
+          <option name="screenX" value="1600" />
+          <option name="screenY" value="2560" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="gts8uwifi" />
+          <option name="formFactor" value="Tablet" />
+          <option name="id" value="gts8uwifi" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Tab S8 Ultra" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="1848" />
+          <option name="screenY" value="2960" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="gts8wifi" />
+          <option name="formFactor" value="Tablet" />
+          <option name="id" value="gts8wifi" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Tab S8" />
+          <option name="screenDensity" value="274" />
+          <option name="screenX" value="1600" />
+          <option name="screenY" value="2560" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="gts9fe" />
+          <option name="id" value="gts9fe" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Tab S9 FE 5G" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="2304" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="gts9wifi" />
+          <option name="id" value="gts9wifi" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-X710" />
+          <option name="screenDensity" value="340" />
+          <option name="screenX" value="1600" />
+          <option name="screenY" value="2560" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="husky" />
+          <option name="id" value="husky" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 8 Pro" />
+          <option name="screenDensity" value="390" />
+          <option name="screenX" value="1008" />
+          <option name="screenY" value="2244" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="30" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="java" />
+          <option name="id" value="java" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="G20" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="komodo" />
+          <option name="id" value="komodo" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9 Pro XL" />
+          <option name="screenDensity" value="360" />
+          <option name="screenX" value="1008" />
+          <option name="screenY" value="2244" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="google" />
+          <option name="codename" value="komodo" />
+          <option name="id" value="komodo" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9 Pro XL" />
+          <option name="screenDensity" value="360" />
+          <option name="screenX" value="1008" />
+          <option name="screenY" value="2244" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="lion" />
+          <option name="id" value="lion" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto g04" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1612" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="google" />
+          <option name="codename" value="lynx" />
+          <option name="id" value="lynx" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 7a" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="lyriq" />
+          <option name="id" value="lyriq" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="edge 40" />
+          <option name="screenDensity" value="400" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="manaus" />
+          <option name="id" value="manaus" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="edge 40 neo" />
+          <option name="screenDensity" value="400" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="maui" />
+          <option name="id" value="maui" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto g play - 2023" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="o1q" />
+          <option name="id" value="o1q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S21" />
+          <option name="screenDensity" value="421" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="31" />
+          <option name="brand" value="google" />
+          <option name="codename" value="oriole" />
+          <option name="id" value="oriole" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 6" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="pa3q" />
+          <option name="id" value="pa3q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S25 Ultra" />
+          <option name="screenDensity" value="600" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3120" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="google" />
+          <option name="codename" value="panther" />
+          <option name="id" value="panther" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 7" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="q5q" />
+          <option name="id" value="q5q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Z Fold5" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1812" />
+          <option name="screenY" value="2176" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="q6q" />
+          <option name="id" value="q6q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Z Fold6" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1856" />
+          <option name="screenY" value="2160" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="30" />
+          <option name="brand" value="google" />
+          <option name="codename" value="r11" />
+          <option name="formFactor" value="Wear OS" />
+          <option name="id" value="r11" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel Watch" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="384" />
+          <option name="screenY" value="384" />
+          <option name="type" value="WEAR_OS" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="r11q" />
+          <option name="id" value="r11q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-S711U" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="30" />
+          <option name="brand" value="google" />
+          <option name="codename" value="redfin" />
+          <option name="id" value="redfin" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 5" />
+          <option name="screenDensity" value="440" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="shiba" />
+          <option name="id" value="shiba" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 8" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="t2q" />
+          <option name="id" value="t2q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S21 Plus" />
+          <option name="screenDensity" value="394" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="google" />
+          <option name="codename" value="tangorpro" />
+          <option name="formFactor" value="Tablet" />
+          <option name="id" value="tangorpro" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel Tablet" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="1600" />
+          <option name="screenY" value="2560" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="google" />
+          <option name="codename" value="tegu" />
+          <option name="id" value="tegu" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9a" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2424" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="tokay" />
+          <option name="default" value="true" />
+          <option name="id" value="tokay" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2424" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="google" />
+          <option name="codename" value="tokay" />
+          <option name="default" value="true" />
+          <option name="id" value="tokay" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2424" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="google" />
+          <option name="codename" value="tokay" />
+          <option name="default" value="true" />
+          <option name="id" value="tokay" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2424" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="xcover7" />
+          <option name="id" value="xcover7" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-G556B" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2408" />
+        </PersistentDeviceSelectionData>
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/caches/deviceStreaming.xml
+++ b/.idea/caches/deviceStreaming.xml
@@ -88,6 +88,19 @@
           <option name="screenY" value="2160" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="Lenovo" />
+          <option name="codename" value="TB330FU" />
+          <option name="formFactor" value="Tablet" />
+          <option name="id" value="TB330FU" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Lenovo" />
+          <option name="name" value="Tab M11" />
+          <option name="screenDensity" value="240" />
+          <option name="screenX" value="1200" />
+          <option name="screenY" value="1920" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
           <option name="codename" value="a14m" />
@@ -547,6 +560,18 @@
           <option name="screenDensity" value="280" />
           <option name="screenX" value="720" />
           <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="kansas" />
+          <option name="id" value="kansas" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto g - 2025" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1604" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/workfolio.iml" filepath="$PROJECT_DIR$/.idea/workfolio.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workfolio.iml
+++ b/.idea/workfolio.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,47 @@
+# Workfolio API Documentation
+
+This directory consolidates backend planning artifacts for the Supabase stack. Start with the high-level goals in `../API.md`, then dive into schema-specific guides stored in dedicated folders here.
+
+## Structure
+- `schemas/` – folder with one subdirectory per domain schema.
+  - `company/COMPANY.md` – tenant master data, plan tiers, and audit governance.
+  - `user/USER.md` – user identity, membership, security, and preferences.
+  - `documents/DOCUMENTS.md` – document categories, templates, issues, and file versions.
+  - `notifications/NOTIFICATIONS.md` – delivery channels, notification queue, and delivery logs.
+  - `events/EVENTS.md` – calendar events, attendees, and holiday cache.
+
+## Schema Connectivity
+```mermaid
+erDiagram
+    COMPANIES ||--o{ COMPANY_MEMBERS : "company_id"
+    AUTH_USERS ||--o{ COMPANY_MEMBERS : "user_id"
+    AUTH_USERS ||--|| USER_PROFILES : "user_id"
+    COMPANY_MEMBERS ||--|| EMPLOYEE_PROFILES : "member_id"
+    AUTH_USERS ||--|| USER_PREFERENCES : "user_id"
+
+    COMPANIES ||--o{ DOCUMENT_CATEGORIES : "company_id"
+    DOCUMENT_CATEGORIES ||--o{ DOCUMENT_TEMPLATES : "category_id"
+    DOCUMENT_TEMPLATES ||--o{ DOCUMENTS : "template_id"
+    EMPLOYEE_PROFILES ||--o{ DOCUMENTS : "employee_id"
+    DOCUMENTS ||--o{ DOCUMENT_FILES : "document_id"
+
+    COMPANIES ||--o{ EVENTS : "company_id"
+    EVENTS ||--o{ EVENT_ATTENDEES : "event_id"
+    COMPANIES ||--o{ HOLIDAY_CALENDARS : "company_id"
+
+    AUTH_USERS ||--o{ NOTIFICATION_CHANNELS : "user_id"
+    COMPANIES ||--o{ NOTIFICATIONS : "company_id"
+    NOTIFICATIONS ||--o{ NOTIFICATION_DELIVERIES : "notification_id"
+    NOTIFICATION_CHANNELS ||--o{ NOTIFICATION_DELIVERIES : "channel_id"
+
+    COMPANIES ||--o{ AUDIT_LOGS : "company_id"
+    AUTH_USERS ||--o{ AUDIT_LOGS : "actor_id"
+```
+
+## Contributing
+1. Create a folder under `schemas/` matching the domain name (kebab-case). Inside, add a `<SCHEMA>.md` file (uppercase, e.g., `PAYROLL.md`) with table definitions, relationships, RLS guidance, lifecycle notes, and a Mermaid diagram.
+2. Link back to relevant rules in `rules/` (e.g., `code-style`, `security`, `analytics-logging`) so policies stay front of mind.
+3. Keep doc updates in sync with Supabase migrations to avoid drift.
+4. Apply schema changes using `yarn db:setup` (set `SUPABASE_DB_URL`, `EXPO_PUBLIC_SUPABASE_URL_DB`, or `EXPO_PUBLIC_SUPABASE_URL_SQL` with the Database connection string from Supabase Settings → Database) so documentation and database stay aligned.
+
+> Tip: Use `yarn lint` before submitting PRs to ensure markdown linting conventions remain consistent.

--- a/api/schemas/README.md
+++ b/api/schemas/README.md
@@ -1,0 +1,11 @@
+# Schema Index
+
+Create one subdirectory per domain schema (e.g., `documents/`, `payroll/`). Inside each directory, document the schema in an uppercase `<SCHEMA>.md` file (e.g., `DOCUMENTS.md`, `PAYROLL.md`) that:
+
+- Summarize the domain purpose and scope.
+- Provide a Mermaid diagram showing relationships to other schemas and shared tables.
+- Describe database tables with column metadata, constraints, defaults, and indexes.
+- Capture RLS policies, triggers, and edge functions.
+- Outline lifecycle flows plus open questions or follow-up tasks.
+
+Use `user/USER.md` as the reference pattern for depth and formatting.

--- a/api/schemas/company/COMPANY.md
+++ b/api/schemas/company/COMPANY.md
@@ -1,0 +1,104 @@
+# Company Domain Schema
+
+Centralizes tenant records, membership, and cross-domain governance for Workfolio. These tables enforce multi-tenant boundaries and seed downstream entities (documents, events, payroll, notifications).
+
+## Scope
+- Represents each customer company with billing, configuration, and lifecycle metadata.
+- Manages user membership, roles, and invite status via `company_members`.
+- Feeds audit/compliance logs and references for dependent domains (documents, events, payroll, notifications).
+
+## Relationship Diagram
+```mermaid
+erDiagram
+    COMPANIES ||--o{ COMPANY_MEMBERS : "company_id"
+    COMPANIES ||--o{ EMPLOYEE_PROFILES : "company_id"
+    COMPANIES ||--o{ DOCUMENT_CATEGORIES : "company_id"
+    COMPANIES ||--o{ DOCUMENT_TEMPLATES : "company_id"
+    COMPANIES ||--o{ DOCUMENTS : "company_id"
+    COMPANIES ||--o{ PAYCHECKS : "company_id"
+    COMPANIES ||--o{ EVENTS : "company_id"
+    COMPANIES ||--o{ HOLIDAY_CALENDARS : "company_id"
+    COMPANIES ||--o{ NOTIFICATIONS : "company_id"
+    COMPANIES ||--o{ AUDIT_LOGS : "company_id"
+    COMPANY_MEMBERS ||--|| USER_PROFILES : "user_id"
+    COMPANY_MEMBERS ||--|| EMPLOYEE_PROFILES : "member_id"
+```
+
+## Table Overview
+| Table | Purpose | Notes |
+| --- | --- | --- |
+| `companies` | Canonical tenant record with plan, locale, and billing metadata. | Drives RLS boundaries for all domain tables. |
+| `company_members` | Associates Supabase users with a company and role. | Detailed definition lives in `schemas/user/USER.md`; summarized here for tenant context. |
+| `audit_logs` | Compliance trail for company-level actions. | Shared domain; entries filtered by `company_id`. |
+
+## Table Definitions
+
+### `companies`
+- **Columns**
+  - `id uuid primary key default uuid_generate_v4()`
+  - `name text not null`
+  - `legal_name text`
+  - `company_code text not null unique`
+  - `country_code text not null` *(ISO 3166-1 alpha-2)*
+  - `default_time_zone text not null default 'UTC'`
+  - `plan_tier text not null default 'trial' check (plan_tier in ('trial','starter','growth','enterprise'))`
+  - `plan_renewal_at timestamptz`
+  - `billing_email text`
+  - `industry text`
+  - `employee_count_estimate integer`
+  - `logo_url text`
+  - `created_by uuid references auth.users(id)`
+  - `created_at timestamptz default now()`
+  - `updated_at timestamptz default now()`
+  - `deactivated_at timestamptz`
+  - `metadata jsonb` *(arbitrary per-tenant settings)*
+- **Indexes**
+  - Unique on `company_code`.
+  - `idx_companies_plan_tier` on (`plan_tier`).
+  - `idx_companies_country` on (`country_code`).
+- **Relationships**
+  - `company_members`, `documents`, `events`, `notifications`, `paychecks`, etc. reference `companies.id`.
+  - `created_by` links back to founding admin (`auth.users`).
+- **RLS Policies**
+  - Allow `select` for users with membership in the company via `company_members` join.
+  - Allow `update`/`delete` only for admins (`role = 'admin'`) within tenant.
+  - Service role can insert for onboarding Edge Function.
+- **Lifecycle**
+  - Created through `rpc_create_company` (see API.md) when admin completes signup.
+  - Plan upgrades adjust `plan_tier` and `metadata` fields; triggers should append entries to `audit_logs`.
+  - Deactivation sets `deactivated_at`, soft-disabling memberships and dependent data via RLS.
+
+### `company_members`
+Refer to `../user/USER.md` for full column breakdown. Key tenant responsibilities:
+- Enforce unique (`company_id`, `user_id`) membership.
+- Drive RLS conditions for every company-scoped table.
+- Provide role-based access (`admin`, `employee`) and status transitions (`invited`, `active`, `suspended`, `left`).
+- Trigger dependent provisioning: on activation, create `employee_profiles` (employees) and `user_preferences` defaults.
+
+### `audit_logs`
+- **Columns**
+  - `id uuid primary key default uuid_generate_v4()`
+  - `company_id uuid not null references companies(id)`
+  - `actor_id uuid references auth.users(id)`
+  - `action text not null`
+  - `severity text not null default 'info'`
+  - `metadata jsonb`
+  - `created_at timestamptz default now()`
+- **Indexes**
+  - `idx_audit_logs_company_time` on (`company_id`, `created_at desc`).
+  - Optional GIN on `metadata` for analytics.
+- **RLS Policies**
+  - Members can read logs for their company (scope by `company_id`).
+  - Insert restricted to service role or trusted RPCs (e.g., executed via Edge Functions).
+- **Lifecycle**
+  - Inserted through triggers on key tables (memberships, plans, documents, etc.) to maintain compliance trail.
+
+## Compliance & Governance Notes
+- All tenant-scoped tables must include `company_id` and rely on RLS policies derived from `company_members`.
+- Plan tier upgrades may unlock features; store entitlements in `metadata` keyed by feature name (e.g., `{ "documents.max_templates": 25 }`).
+- Deleting a company should be soft only; Archive records, revoke access, and queue storage cleanup asynchronously to honour retention policies.
+
+## Outstanding Work
+- Model `subscriptions` and billing linkage once pricing strategy is finalized.
+- Define automation rules for cascading deactivation (e.g., disable notifications, cancel events) when `deactivated_at` is set.
+- Document support workflows for changing `company_code` safely across references.

--- a/api/schemas/documents/DOCUMENTS.md
+++ b/api/schemas/documents/DOCUMENTS.md
@@ -1,0 +1,137 @@
+# Documents Domain Schema
+
+Models the lifecycle of HR documents from template authoring through employee acknowledgment. Aligns with the documentation strategy outlined in `API.md`.
+
+## Scope
+- Categorizes documents per company and seeds reusable templates.
+- Tracks issued documents per employee, signatures, and deadlines.
+- Links uploaded files and version history stored in Supabase Storage.
+
+## Relationship Diagram
+```mermaid
+erDiagram
+    COMPANIES ||--o{ DOCUMENT_CATEGORIES : "company_id"
+    COMPANIES ||--o{ DOCUMENT_TEMPLATES : "company_id"
+    DOCUMENT_CATEGORIES ||--o{ DOCUMENT_TEMPLATES : "category_id"
+    COMPANIES ||--o{ DOCUMENTS : "company_id"
+    DOCUMENT_TEMPLATES ||--o{ DOCUMENTS : "template_id"
+    EMPLOYEE_PROFILES ||--o{ DOCUMENTS : "employee_id"
+    DOCUMENTS ||--o{ DOCUMENT_FILES : "document_id"
+    AUTH_USERS ||--o{ DOCUMENTS : "signed_by"
+    AUTH_USERS ||--o{ DOCUMENT_FILES : "uploaded_by"
+    COMPANIES ||--o{ DOCUMENT_FILES : "company_id"
+```
+
+## Table Overview
+| Table | Purpose | Notes |
+| --- | --- | --- |
+| `document_categories` | Admin-defined taxonomy for grouping documents. | Scoped per company; enables filtering in UI. |
+| `document_templates` | Reusable templates seeded by admins. | Drives issued documents; can be published/unpublished. |
+| `documents` | Instances assigned to employees. | Tracks status, signature state, due dates. |
+| `document_files` | Versioned file storage references. | Supports template source files and signed uploads. |
+
+## Table Definitions
+
+### `document_categories`
+- **Columns**
+  - `id uuid primary key default uuid_generate_v4()`
+  - `company_id uuid not null references companies(id)`
+  - `name text not null`
+  - `description text`
+  - `is_active boolean not null default true`
+  - `created_by uuid references auth.users(id)`
+  - `created_at timestamptz default now()`
+  - `updated_at timestamptz default now()`
+- **Indexes**
+  - Unique (`company_id`, `name`).
+  - `idx_document_categories_active` on (`company_id`, `is_active`).
+- **RLS Policies**
+  - Admins (`company_members.role = 'admin'`) manage categories within their company.
+  - Employees receive `select` access for active categories via tenant join.
+
+### `document_templates`
+- **Columns**
+  - `id uuid primary key default uuid_generate_v4()`
+  - `company_id uuid not null references companies(id)`
+  - `category_id uuid references document_categories(id)`
+  - `title text not null`
+  - `description text`
+  - `requires_signature boolean not null default true`
+  - `is_published boolean not null default false`
+  - `valid_from date`
+  - `valid_until date`
+  - `default_due_days integer` *(days after issue to set `due_at`)*
+  - `version integer not null default 1`
+  - `last_published_at timestamptz`
+  - `created_by uuid references auth.users(id)`
+  - `updated_by uuid references auth.users(id)`
+  - `created_at timestamptz default now()`
+  - `updated_at timestamptz default now()`
+- **Indexes**
+  - `idx_document_templates_company_status` on (`company_id`, `is_published`).
+  - `idx_document_templates_category` on (`category_id`).
+- **Lifecycle Notes**
+  - Draft templates remain `is_published = false` until reviewed.
+  - Publishing increments `version` and stamps `last_published_at`.
+  - Superseded templates remain for audit; new issues reference the current `version`.
+
+### `documents`
+- **Columns**
+  - `id uuid primary key default uuid_generate_v4()`
+  - `company_id uuid not null references companies(id)`
+  - `template_id uuid references document_templates(id)`
+  - `employee_id uuid not null references employee_profiles(id)`
+  - `title text not null`
+  - `status text not null default 'pending' check (status in ('pending','signed','rejected','expired'))`
+  - `issued_at timestamptz default now()`
+  - `due_at timestamptz`
+  - `signed_at timestamptz`
+  - `signed_by uuid references auth.users(id)`
+  - `rejected_at timestamptz`
+  - `rejected_reason text`
+  - `expired_at timestamptz`
+  - `metadata jsonb`
+  - `created_by uuid references auth.users(id)`
+  - `updated_at timestamptz default now()`
+- **Indexes**
+  - `idx_documents_employee_status` on (`employee_id`, `status`).
+  - `idx_documents_company_due` on (`company_id`, `due_at`).
+- **RLS Policies**
+  - Employees can `select` documents where `employee_id` maps back to their membership.
+  - Admins can manage documents within their company.
+  - Inserts limited to admins/service roles (issue automation).
+- **Lifecycle Notes**
+  - Follow lifecycle `draft → issued → pending → signed/rejected/expired` per API guidance.
+  - Status transitions trigger `audit_logs` entries and `notifications` fan-out.
+  - `metadata` reserved for e-sign provider payloads or acknowledgments.
+
+### `document_files`
+- **Columns**
+  - `id uuid primary key default uuid_generate_v4()`
+  - `company_id uuid not null references companies(id)`
+  - `document_id uuid references documents(id)`
+  - `template_id uuid references document_templates(id)` *(optional linkage for template source)*
+  - `file_path text not null`
+  - `file_size integer`
+  - `content_type text`
+  - `version integer not null default 1`
+  - `uploaded_by uuid references auth.users(id)`
+  - `uploaded_at timestamptz default now()`
+  - `checksum text` *(integrity verification)*
+- **Indexes**
+  - `idx_document_files_document_version` on (`document_id`, `version` desc).
+  - `idx_document_files_template` on (`template_id`).
+- **Lifecycle Notes**
+  - File path pattern: `company/{company_id}/documents/{document_id or template_id}/{version}` per API.md.
+  - Maintain version history; never delete signed documents (compliance).
+  - Metadata can track signed URL expiry or provider references if needed.
+
+## RLS & Compliance Considerations
+- Enforce tenant isolation using `company_id` filters resolved via `company_members`/`employee_profiles` joins.
+- Mask sensitive data in employee view (e.g., hide `rejected_reason`) using Postgres views or column-level policies if required.
+- Trigger `audit_logs` on template publishes, document issues, and signature outcomes.
+
+## Outstanding Work
+- Define automation for seeding default templates during company onboarding.
+- Determine whether countersignature workflows are needed (e.g., manager sign-off) and extend schema accordingly.
+- Evaluate storing OCR/parsed data for search; would require additional tables or search indexes.

--- a/api/schemas/events/EVENTS.md
+++ b/api/schemas/events/EVENTS.md
@@ -1,0 +1,102 @@
+# Events Domain Schema
+
+Captures company calendars, targeted attendees, and holiday caching to power Workfolio's scheduling features.
+
+## Scope
+- Stores company-wide and targeted events with metadata for reminders.
+- Manages optional attendee lists when events are not organization-wide.
+- Caches holidays per company/country for auto-generated events.
+
+## Relationship Diagram
+```mermaid
+erDiagram
+    COMPANIES ||--o{ EVENTS : "company_id"
+    EVENTS ||--o{ EVENT_ATTENDEES : "event_id"
+    EVENTS ||--o{ NOTIFICATIONS : "event reminders"
+    EMPLOYEE_PROFILES ||--o{ EVENT_ATTENDEES : "employee_id"
+    COMPANIES ||--o{ HOLIDAY_CALENDARS : "company_id"
+    HOLIDAY_CALENDARS ||--o{ EVENTS : "seeded events"
+    AUTH_USERS ||--o{ EVENTS : "created_by"
+```
+
+## Table Overview
+| Table | Purpose | Notes |
+| --- | --- | --- |
+| `events` | Master record for company events. | Supports types (`company`, `birthday`, `holiday`, `hr_event`). |
+| `event_attendees` | Optional attendee targeting. | Rows exist only when event is limited. |
+| `holiday_calendars` | Cached holidays for auto events. | Seeded per company/country. |
+
+## Table Definitions
+
+### `events`
+- **Columns**
+  - `id uuid primary key default uuid_generate_v4()`
+  - `company_id uuid not null references companies(id)`
+  - `type text not null check (type in ('company','birthday','holiday','hr_event'))`
+  - `title text not null`
+  - `description text`
+  - `start_at timestamptz not null`
+  - `end_at timestamptz`
+  - `is_all_day boolean not null default false`
+  - `source text not null default 'manual' check (source in ('manual','generated','imported'))`
+  - `location text`
+  - `created_by uuid references auth.users(id)`
+  - `updated_by uuid references auth.users(id)`
+  - `created_at timestamptz default now()`
+  - `updated_at timestamptz default now()`
+  - `cancelled_at timestamptz`
+  - `metadata jsonb` *(ICS IDs, external links, etc.)*
+- **Indexes**
+  - `idx_events_company_start` on (`company_id`, `start_at`).
+  - `idx_events_type` on (`company_id`, `type`).
+  - Partial index on `cancelled_at is null` for active events.
+- **Lifecycle Notes**
+  - Auto-generated birthdays originate from `employee_profiles.birthday` via scheduled job.
+  - Holiday events seeded from `holiday_calendars` and can be overridden (set `cancelled_at`).
+  - Reminder notifications scheduled 24h prior through Edge Function; references stored in `notifications`.
+
+### `event_attendees`
+- **Columns**
+  - `id uuid primary key default uuid_generate_v4()`
+  - `event_id uuid not null references events(id) on delete cascade`
+  - `employee_id uuid not null references employee_profiles(id)`
+  - `response_status text not null default 'pending' check (response_status in ('pending','accepted','declined'))`
+  - `notified_at timestamptz`
+  - `response_at timestamptz`
+  - `metadata jsonb`
+- **Indexes**
+  - Unique (`event_id`, `employee_id`).
+  - `idx_event_attendees_employee` on (`employee_id`).
+- **Lifecycle Notes**
+  - Rows created only when event is not company-wide; absence implies full-company event.
+  - Response updates drive analytics and optional follow-up notifications.
+  - `notified_at` timestamps when initial reminder is sent.
+
+### `holiday_calendars`
+- **Columns**
+  - `id uuid primary key default uuid_generate_v4()`
+  - `company_id uuid not null references companies(id)`
+  - `country_code text not null`
+  - `name text not null`
+  - `date date not null`
+  - `source text not null` *(e.g., 'workable_api', 'manual')*
+  - `is_observed boolean not null default true`
+  - `created_at timestamptz default now()`
+  - `updated_at timestamptz default now()`
+- **Indexes**
+  - `idx_holiday_calendars_company_date` on (`company_id`, `date`).
+  - `idx_holiday_calendars_country` on (`country_code`, `date`).
+- **Lifecycle Notes**
+  - Refreshed periodically via Edge Function syncing from external holiday provider.
+  - Admin overrides (disable/rename) update the record and propagate to upcoming events.
+
+## RLS & Compliance Considerations
+- `events`: allow `select` for all members within tenant; `update/delete` restricted to admins (`role = 'admin'`) or creator for manual events.
+- `event_attendees`: employees can view attendance rows where they are the attendee; admins can manage all rows.
+- `holiday_calendars`: read-only for employees; admins/service roles can modify.
+- Related notifications should reference `company_id` to maintain tenant isolation in delivery workers.
+
+## Outstanding Work
+- Define ICS export/table for integration with external calendars when feature is prioritized.
+- Determine retention policy for past events and attendance data (e.g., purge after 2 years).
+- Expand schema if team-based targeting (`teams` table) becomes available; will introduce additional join table.

--- a/api/schemas/notifications/NOTIFICATIONS.md
+++ b/api/schemas/notifications/NOTIFICATIONS.md
@@ -1,0 +1,107 @@
+# Notifications Domain Schema
+
+Defines how Workfolio records delivery endpoints, queues outbound messages, and audits delivery attempts.
+
+## Scope
+- Registers user-level channels (push tokens, emails) with verification state.
+- Queues notifications produced by business events (documents, paychecks, events).
+- Logs per-channel delivery attempts for audit, retries, and analytics.
+
+## Relationship Diagram
+```mermaid
+erDiagram
+    AUTH_USERS ||--o{ NOTIFICATION_CHANNELS : "user_id"
+    COMPANIES ||--o{ NOTIFICATION_CHANNELS : "company_id"
+    AUTH_USERS ||--|| USER_PREFERENCES : "user_id"
+    COMPANIES ||--o{ NOTIFICATIONS : "company_id"
+    NOTIFICATIONS ||--o{ NOTIFICATION_DELIVERIES : "notification_id"
+    NOTIFICATION_CHANNELS ||--o{ NOTIFICATION_DELIVERIES : "channel_id"
+    NOTIFICATIONS ||--o{ AUDIT_LOGS : "via triggers"
+```
+
+## Table Overview
+| Table | Purpose | Notes |
+| --- | --- | --- |
+| `notification_channels` | Stores user delivery endpoints (push/email). | Supports verification and last-seen timestamps. |
+| `notifications` | Enqueued notification payloads. | Categorized by source and priority. |
+| `notification_deliveries` | Delivery outcomes per channel. | Tracks status, timestamps, failure reasons. |
+
+## Table Definitions
+
+### `notification_channels`
+- **Columns**
+  - `id uuid primary key default uuid_generate_v4()`
+  - `company_id uuid references companies(id)` *(null for global channels such as personal email)*
+  - `user_id uuid not null references auth.users(id)`
+  - `type text not null check (type in ('push','email'))`
+  - `target text not null` *(Expo token, email address)*
+  - `is_verified boolean not null default false`
+  - `verification_code text`
+  - `verification_expires_at timestamptz`
+  - `last_seen_at timestamptz`
+  - `device_info jsonb`
+  - `created_at timestamptz default now()`
+  - `updated_at timestamptz default now()`
+- **Indexes**
+  - Unique on (`type`, `target`) to avoid duplicates.
+  - `idx_notification_channels_user_type` on (`user_id`, `type`).
+  - Optional partial index where `is_verified = true` for routing.
+- **Lifecycle Notes**
+  - Created by client when registering device/email; unverified channels require confirmation flow.
+  - `last_seen_at` updated when a delivery succeeds using that channel.
+  - Stale channels (no activity for N days) can be pruned by scheduled job.
+
+### `notifications`
+- **Columns**
+  - `id uuid primary key default uuid_generate_v4()`
+  - `company_id uuid references companies(id)`
+  - `category text not null` *(e.g., 'document', 'payroll', 'event')*
+  - `title text not null`
+  - `body text`
+  - `payload jsonb` *(structured data for clients)*
+  - `priority text not null default 'normal' check (priority in ('low','normal','high'))`
+  - `target_scope text not null default 'user' check (target_scope in ('user','company','custom'))`
+  - `target_user_id uuid references auth.users(id)`
+  - `target_employee_id uuid references employee_profiles(id)`
+  - `source_reference text` *(document/paycheck/event id string)*
+  - `scheduled_at timestamptz`
+  - `created_by uuid references auth.users(id)` *(system/service id for automation)*
+  - `created_at timestamptz default now()`
+- **Indexes**
+  - `idx_notifications_company_created` on (`company_id`, `created_at desc`).
+  - Partial index on (`target_user_id`) where `target_scope = 'user'`.
+- **Lifecycle Notes**
+  - Inserted by domain triggers or RPCs (documents issued, paychecks published, event reminders).
+  - Edge Function polls for unsent notifications, resolves eligible channels via `notification_channels` + `user_preferences`.
+  - Completion triggers creation of `notification_deliveries` per channel.
+
+### `notification_deliveries`
+- **Columns**
+  - `id uuid primary key default uuid_generate_v4()`
+  - `notification_id uuid not null references notifications(id) on delete cascade`
+  - `channel_id uuid not null references notification_channels(id)`
+  - `status text not null default 'pending' check (status in ('pending','sent','failed','read'))`
+  - `sent_at timestamptz`
+  - `read_at timestamptz`
+  - `fail_reason text`
+  - `retry_count integer not null default 0`
+  - `metadata jsonb` *(provider response, Expo receipt, etc.)*
+  - `created_at timestamptz default now()`
+- **Indexes**
+  - `idx_notification_deliveries_notification` on (`notification_id`).
+  - Partial index on (`status`) where `status = 'failed'` for retry workers.
+- **Lifecycle Notes**
+  - Worker updates `status`/`sent_at`/`fail_reason` post delivery attempt.
+  - Client confirmations (e.g., reading notifications) can update `read_at` through RPC.
+  - Retention policy can purge rows after 180 days while preserving summary metrics in analytics views.
+
+## RLS & Compliance Considerations
+- `notification_channels`: users manage their own channels; admins can view for company-level debugging if `company_members.role = 'admin'`.
+- `notifications`: restrict `select` to recipients (matching user/company) and admins; service role handles inserts.
+- `notification_deliveries`: only the owning user (via channel) and admins can view; updates limited to delivery worker/service role.
+- All writes should append `audit_logs` entries for critical actions (channel verification, admin overrides).
+
+## Outstanding Work
+- Define `notification_preferences` view or join logic that merges `user_preferences` flags with channel availability.
+- Implement retention job to archive notifications beyond compliance window.
+- Document error-handling expectations for third-party providers (Expo, email) and map to `fail_reason` codes.

--- a/api/schemas/user/USER.md
+++ b/api/schemas/user/USER.md
@@ -1,0 +1,183 @@
+# User Domain Schema
+
+Authoritative reference for Workfolio's user identity, membership, security, and preference tables. Aligns with the backend plan in `API.md` and informs Supabase migration work.
+
+## Scope
+- Models every Supabase-authenticated person (admins and employees).
+- Tracks tenant membership, HR-specific employment data, and security credentials (PIN, biometrics metadata).
+- Centralizes notification targets and user-configurable preferences that power the mobile settings screen.
+
+## Relationship Diagram
+```mermaid
+erDiagram
+    AUTH_USERS ||--|| USER_PROFILES : "user_id"
+    AUTH_USERS ||--o{ COMPANY_MEMBERS : "user_id"
+    COMPANIES ||--o{ COMPANY_MEMBERS : "company_id"
+    COMPANY_MEMBERS ||--|| EMPLOYEE_PROFILES : "member_id"
+    COMPANIES ||--o{ EMPLOYEE_PROFILES : "company_id"
+    AUTH_USERS ||--|| USER_PREFERENCES : "user_id"
+    COMPANIES ||--o{ USER_PREFERENCES : "company_id"
+    AUTH_USERS ||--o{ NOTIFICATION_CHANNELS : "user_id"
+    AUTH_USERS ||--o{ AUDIT_LOGS : "actor_id"
+```
+
+## Table Overview
+| Table | Purpose | Notes |
+| --- | --- | --- |
+| `auth.users` | Base Supabase auth identity. | Managed by Supabase; Workfolio stores metadata for roles and onboarding status. |
+| `user_profiles` | Extended profile for all users. | Lives 1:1 with `auth.users`; holds display data and localization fields. |
+| `company_members` | Links a user to a tenant and role. | Enforces multi-tenant scoping (`company_id`) and account lifecycle. |
+| `employee_profiles` | HR-only employee record. | Exists only for members with `role = 'employee'`; contains sensitive employment and PIN info. |
+| `user_preferences` *(planned)* | User-configurable settings. | Drives notification opt-ins, theme and biometric prompts. |
+
+## Table Definitions
+
+### `auth.users`
+- **Managed Columns**: `id (uuid PK)`, `email`, `phone`, `created_at`, `last_sign_in_at`, `is_anonymous`, `raw_user_meta_data`
+- **Workfolio Metadata**
+  - `raw_user_meta_data.role` (`'admin' | 'employee'`) mirrors `company_members.role` for quick access.
+  - `raw_user_meta_data.invite_context` stores `company_code` used during onboarding.
+  - `raw_user_meta_data.settings_version` increments when preference schema changes; used for forced refreshes on the client.
+- **Indexes / Constraints**: Supabase-managed unique indexes on `email`, `phone`. No custom indexes required.
+- **RLS**: Supabase handles auth RLS; downstream tables enforce tenant isolation. Avoid direct queries where possible—join through `company_members`.
+
+### `user_profiles`
+- **Columns**
+  - `user_id uuid primary key references auth.users(id)`
+  - `full_name text not null`
+  - `preferred_name text`
+  - `avatar_url text`
+  - `phone text`
+  - `time_zone text not null default 'UTC'`
+  - `locale text not null default 'en'`
+  - `bio text`
+  - `created_at timestamptz default now()`
+  - `updated_at timestamptz default now()`
+- **Indexes**
+  - `idx_user_profiles_locale` on (`locale`) for localization analytics.
+  - `idx_user_profiles_time_zone` on (`time_zone`) to support scheduling queries.
+- **Relationships**: One-to-one with `auth.users`; join on `user_id`. `company_members` references `user_profiles` for display names.
+- **RLS Policies**
+  - `user can view/update own profile`: `user_id = auth.uid()`.
+  - `admins can read members`: join via `company_members` where `company_members.role = 'admin'` and `company_id` matches.
+- **Lifecycle**: Inserted immediately after Supabase signup (Edge function). Updates via settings screen patch route.
+
+### `company_members`
+- **Columns**
+  - `id uuid primary key default uuid_generate_v4()`
+  - `company_id uuid not null references companies(id)`
+  - `user_id uuid not null references auth.users(id)`
+  - `role text not null check (role in ('admin','employee'))`
+  - `status text not null default 'invited' check (status in ('invited','active','suspended','left'))`
+  - `invited_at timestamptz default now()`
+  - `joined_at timestamptz`
+  - `suspended_at timestamptz`
+  - `invited_by uuid references auth.users(id)`
+  - `note text`
+  - `created_at timestamptz default now()`
+- **Indexes / Constraints**
+  - Unique (`company_id`, `user_id`).
+  - `idx_company_members_company_role` on (`company_id`, `role`).
+  - `idx_company_members_status` on (`company_id`, `status`).
+- **Relationships**
+  - `companies` ←→ `company_members` ←→ `auth.users`.
+  - `employee_profiles.member_id` foreign key to `company_members.id` (employee-only rows).
+  - Used by RLS across domain tables (`company_id` scoping).
+- **RLS Policies**
+  - `Members can read peers in same company`: filter by `company_id` via subquery using `auth.uid()`.
+  - `Admins manage memberships`: only rows with `role = 'admin'` and same `company_id` can insert/update.
+  - `Self` updates limited to status transitions like `left` (future automation).
+- **Lifecycle**
+  - Created when admin invites or when user self-joins with `company_code`.
+  - `status` transitions: `invited` → `active` on acceptance; `suspended` via admin action; `left` when user is deactivated.
+  - Deleting membership triggers cascade removal of `employee_profiles` and disables preferences (planned via triggers).
+
+### `employee_profiles`
+- **Columns**
+  - `id uuid primary key default uuid_generate_v4()`
+  - `company_id uuid not null references companies(id)`
+  - `member_id uuid not null references company_members(id)`
+  - `employee_number text`
+  - `job_title text`
+  - `department text`
+  - `manager_member_id uuid references company_members(id)`
+  - `birthday date`
+  - `hire_date date`
+  - `termination_date date`
+  - `is_active boolean not null default true`
+  - `pin_hash text` *(bcrypt/argon2 hashed PIN)*
+  - `pin_failed_attempts smallint not null default 0`
+  - `pin_locked_until timestamptz`
+  - `pin_last_reset_at timestamptz`
+  - `emergency_contact jsonb`
+  - `address jsonb`
+  - `created_at timestamptz default now()`
+  - `updated_at timestamptz default now()`
+- **Indexes**
+  - Unique (`company_id`, `employee_number`).
+  - `idx_employee_profiles_company_manager` on (`company_id`, `manager_member_id`).
+  - `idx_employee_profiles_active` on (`company_id`, `is_active`).
+- **Relationships**
+  - Tied to `documents`, `paychecks`, `events`, `notification_deliveries`, and other domain tables via `employee_id` (which references `employee_profiles.id`).
+  - Manager references enforce org hierarchy.
+- **RLS Policies**
+  - `Employees view limited self fields`: allow select on own `member_id`, restrict sensitive columns via column-level policies or views.
+  - `Admins/HR` (role = `admin`) can select/update within same `company_id`.
+  - Write operations constrained to service roles for payroll imports (via Edge Functions with elevated key).
+- **Lifecycle**
+  - Provisioned when employee accepts invite and completes onboarding forms.
+  - Deactivation sets `is_active = false`, stamps `termination_date`, resets PIN data, and triggers audit entry.
+
+### `user_preferences` *(new table proposal)*
+- **Purpose**: Persist per-user settings exposed through the mobile settings screen and upcoming web dashboard.
+- **Columns**
+  - `user_id uuid primary key references auth.users(id)`
+  - `company_id uuid references companies(id)` *(nullable for cross-tenant admins)*
+  - `theme text not null default 'system' check (theme in ('system','light','dark'))`
+  - `language text references i18n_locales(code) default 'en'`
+  - `timezone_override text`
+  - `receive_company_announcements boolean not null default true`
+  - `receive_payroll_notifications boolean not null default true`
+  - `receive_document_prompts boolean not null default true`
+  - `biometric_auth_enabled boolean not null default false`
+  - `pin_required_for_sensitive boolean not null default true`
+  - `marketing_opt_in boolean not null default false`
+  - `created_at timestamptz default now()`
+  - `updated_at timestamptz default now()`
+  - `updated_by uuid references auth.users(id)` *(tracks admin overrides)*
+- **Indexes**
+  - `idx_user_preferences_company` on (`company_id`).
+  - `idx_user_preferences_flags` partial indexes on flag columns if analytics needs arise (evaluate during implementation).
+- **Relationships**
+  - Joins to `notification_channels` to determine valid delivery paths.
+  - References `audit_logs` for change tracking (`actor_id` = `updated_by`).
+- **RLS Policies**
+  - `Self-service`: `auth.uid() = user_id` for select/update.
+  - `Admin override`: allow update where `company_members.role = 'admin'` and `company_id` matches, plus log to `audit_logs` via trigger.
+- **Lifecycle**
+  - Inserted with defaults when membership is activated.
+  - Updated via settings screen or admin overrides; each update increments `raw_user_meta_data.settings_version` to notify clients.
+
+## Relationships & Data Flow
+1. **Signup**
+   - Supabase creates `auth.users` row → Edge function seeds `user_profiles` and provisional `company_members` (status `invited`).
+2. **Join Company**
+   - User enters `company_code`, membership activated, `user_preferences` defaults inserted, optional `employee_profiles` row created if role `employee`.
+3. **Settings Updates**
+   - Client writes to `user_profiles`, `user_preferences`; triggers append `audit_logs` entry and sync `settings_version`.
+4. **Security Events**
+   - PIN/Biometric changes update `employee_profiles` (PIN columns) and create `paycheck_signature_events` records when signing payroll docs.
+5. **Notifications**
+   - `user_preferences` opt-ins inform `notifications` routing; `notification_channels` and `notification_deliveries` reference the same `user_id`.
+
+## RLS & Compliance Considerations
+- All domain tables must enforce tenant isolation via `company_members`. When adding new views or functions, ensure queries resolve `company_id` through a join on `member_id` or `user_id`.
+- Sensitive columns (`pin_hash`, address, emergency contact) should be shielded from general employee access. Consider exposing sanitized views for employee self-service while restricting base table selects to service roles and admins.
+- Every update to membership, profile, or preferences should invoke `audit_logs` with `actor_id`, `action`, and `metadata` describing old/new values.
+
+## Decisions & Open Items
+- **Preference history**: Implement soft-delete snapshots to preserve change history (e.g., archive row before update). Detail migration strategy when building Supabase scripts.
+- **Channel overrides**: Not required initially; retain consolidated boolean toggles and revisit if analytics demands finer granularity.
+- **Multi-company admins**: Out of scope for now; single preference row per user remains sufficient until cross-tenant admin support is prioritized.
+
+Use this document as the blueprint when creating Supabase migrations, API handlers, and settings UI bindings.

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -32,13 +32,17 @@ export default function LoginScreen() {
     try {
       await signIn(values);
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unable to sign in with those credentials.';
+      const message =
+        error instanceof Error ? error.message : 'Unable to sign in with those credentials.';
       Alert.alert('Sign-in failed', message);
     }
   };
 
   const handleGoogleSignIn = async () => {
-    Alert.alert('Integración pendiente', 'Inicia sesión con correo y contraseña mientras configuramos Google.');
+    Alert.alert(
+      'Integración pendiente',
+      'Inicia sesión con correo y contraseña mientras configuramos Google.',
+    );
   };
 
   return (

--- a/app/(auth)/recover.tsx
+++ b/app/(auth)/recover.tsx
@@ -32,7 +32,8 @@ export default function RecoverScreen() {
       setIsRequestSent(true);
       reset(values);
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'No pudimos enviar el correo de recuperación.';
+      const message =
+        error instanceof Error ? error.message : 'No pudimos enviar el correo de recuperación.';
       Alert.alert('Error al recuperar acceso', message);
     }
   };

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -66,7 +66,7 @@ const signUpSchema = z
   });
 
 export default function SignUpScreen() {
-  const { control, handleSubmit, formState } = useForm<SignUpFormValues>({
+  const { control, handleSubmit, formState, watch } = useForm<SignUpFormValues>({
     defaultValues: {
       fullName: '',
       email: '',
@@ -85,6 +85,8 @@ export default function SignUpScreen() {
   });
   const { register, isAuthLoading } = useAuth();
   const isBusy = formState.isSubmitting || isAuthLoading;
+  const companyCodeValue = watch('companyCode');
+  const isJoiningExisting = Boolean((companyCodeValue ?? '').trim());
 
   const onSubmit = async (values: SignUpFormValues) => {
     try {
@@ -164,6 +166,7 @@ export default function SignUpScreen() {
                 label="Company name"
                 autoCapitalize="words"
                 helperText="Obligatorio solo si creás una nueva empresa desde cero."
+                inputProps={{ isDisabled: isJoiningExisting }}
               />
               <ControllerInput
                 control={control}
@@ -171,6 +174,7 @@ export default function SignUpScreen() {
                 label="Country (ISO 3166-1)"
                 autoCapitalize="characters"
                 helperText="Ejemplo: AR, US, ES. Obligatorio para crear una nueva empresa."
+                inputProps={{ isDisabled: isJoiningExisting }}
               />
               <ControllerInput
                 control={control}
@@ -178,12 +182,14 @@ export default function SignUpScreen() {
                 label="Default time zone"
                 autoCapitalize="none"
                 helperText="Ejemplo: America/Argentina/Buenos_Aires. Obligatorio para crear una nueva empresa."
+                inputProps={{ isDisabled: isJoiningExisting }}
               />
               <ControllerInput
                 control={control}
                 name="industry"
                 label="Industry"
                 autoCapitalize="words"
+                inputProps={{ isDisabled: isJoiningExisting }}
               />
               <ControllerInput
                 control={control}
@@ -191,12 +197,18 @@ export default function SignUpScreen() {
                 label="Billing email"
                 keyboardType="email-address"
                 autoCapitalize="none"
+                inputProps={{ isDisabled: isJoiningExisting }}
               />
               <ControllerInput
                 control={control}
                 name="companyDescription"
                 label="Company description"
-                inputProps={{ multiline: true, numberOfLines: 3, placeholder: 'Breve descripción' }}
+                inputProps={{
+                  isDisabled: isJoiningExisting,
+                  multiline: true,
+                  numberOfLines: 3,
+                  placeholder: 'Breve descripción',
+                }}
               />
             </View>
 

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -1,7 +1,15 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Link } from 'expo-router';
 import { useForm } from 'react-hook-form';
-import { Alert, Pressable, Text, View } from 'react-native';
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native';
 import { z } from 'zod';
 
 import { ControllerInput } from '@/components/custom/ControllerInput';
@@ -10,30 +18,77 @@ import { cn } from '@/lib/cn';
 import { useAuth } from '@/hooks/useAuth';
 import type { SignUpFormValues } from '@/types/screens/auth';
 
+const optionalTrimmedField = z
+  .string()
+  .optional()
+  .transform((value) => {
+    const trimmed = value?.trim() ?? '';
+    return trimmed.length > 0 ? trimmed : undefined;
+  });
+
 const signUpSchema = z
   .object({
     fullName: z.string().min(2, 'Name must be at least 2 characters'),
     email: z.string().email('Please enter a valid email'),
     password: z.string().min(6, 'Password must be at least 6 characters'),
     confirmPassword: z.string().min(6, 'Confirm your password'),
+    companyCode: z
+      .string()
+      .optional()
+      .transform((value) => {
+        const trimmed = value?.trim() ?? '';
+        return trimmed.length > 0 ? trimmed.toUpperCase() : undefined;
+      }),
+    companyName: optionalTrimmedField,
+    countryCode: optionalTrimmedField,
+    defaultTimeZone: optionalTrimmedField,
+    industry: optionalTrimmedField,
+    billingEmail: optionalTrimmedField,
+    companyDescription: optionalTrimmedField,
   })
   .refine((values) => values.password === values.confirmPassword, {
     message: 'Passwords must match',
     path: ['confirmPassword'],
+  })
+  .superRefine((values, ctx) => {
+    const wantsToJoinExisting = Boolean(values.companyCode);
+    const hasCreationFields = Boolean(
+      values.companyName && values.countryCode && values.defaultTimeZone,
+    );
+
+    if (!wantsToJoinExisting && !hasCreationFields) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['companyCode'],
+        message: 'Ingresá el código de tu empresa o completa los datos para crear una nueva.',
+      });
+    }
   });
 
 export default function SignUpScreen() {
   const { control, handleSubmit, formState } = useForm<SignUpFormValues>({
-    defaultValues: { fullName: '', email: '', password: '', confirmPassword: '' },
+    defaultValues: {
+      fullName: '',
+      email: '',
+      password: '',
+      confirmPassword: '',
+      companyCode: '',
+      companyName: '',
+      countryCode: '',
+      defaultTimeZone: '',
+      industry: '',
+      billingEmail: '',
+      companyDescription: '',
+    },
     resolver: zodResolver(signUpSchema),
     mode: 'onChange',
   });
   const { register, isAuthLoading } = useAuth();
   const isBusy = formState.isSubmitting || isAuthLoading;
 
-  const onSubmit = async ({ email, password, fullName }: SignUpFormValues) => {
+  const onSubmit = async (values: SignUpFormValues) => {
     try {
-      const { emailConfirmationRequired } = await register({ email, password, fullName });
+      const { emailConfirmationRequired } = await register(values);
 
       if (emailConfirmationRequired) {
         Alert.alert(
@@ -49,68 +104,126 @@ export default function SignUpScreen() {
 
   return (
     <GradientBackground>
-      <View className="flex-1 justify-center gap-8 bg-white/85 px-6 py-10 dark:bg-zinc-950/85">
-        <View className="gap-2">
-          <Text className="text-4xl font-semibold text-slate-900 dark:text-slate-100">
-            Create account
-          </Text>
-          <Text className="text-base text-slate-500 dark:text-slate-400">
-            Start managing your workfolio
-          </Text>
-        </View>
-
-        <View className="gap-4">
-          <ControllerInput
-            control={control}
-            name="fullName"
-            label="Full name"
-            autoCapitalize="words"
-          />
-          <ControllerInput
-            control={control}
-            name="email"
-            label="Email"
-            autoCapitalize="none"
-            keyboardType="email-address"
-          />
-          <ControllerInput
-            control={control}
-            name="password"
-            label="Password"
-            secureTextEntry
-            textContentType="newPassword"
-          />
-          <ControllerInput
-            control={control}
-            name="confirmPassword"
-            label="Confirm password"
-            secureTextEntry
-            textContentType="newPassword"
-          />
-        </View>
-
-        <Pressable
-          className={cn(
-            'items-center justify-center rounded-xl bg-primary-600 px-5 py-3',
-            isBusy && 'opacity-60',
-          )}
-          disabled={isBusy}
-          onPress={handleSubmit(onSubmit)}
+      <KeyboardAvoidingView
+        className="flex-1"
+        behavior={Platform.select({ ios: 'padding', android: undefined })}
+      >
+        <ScrollView
+          className="flex-1"
+          contentContainerStyle={{ paddingVertical: 40 }}
+          keyboardShouldPersistTaps="handled"
         >
-          <Text className="text-base font-semibold text-white">Sign Up</Text>
-        </Pressable>
+          <View className="gap-8 bg-white/85 px-6 py-10 dark:bg-zinc-950/85">
+            <View className="gap-2">
+              <Text className="text-4xl font-semibold text-slate-900 dark:text-slate-100">
+                Create account
+              </Text>
+              <Text className="text-base text-slate-500 dark:text-slate-400">
+                Start managing your workfolio
+              </Text>
+            </View>
 
-        <View className="flex-row items-center justify-center gap-1">
-          <Text className="text-sm text-slate-500 dark:text-slate-400">
-            Already have an account?
-          </Text>
-          <Link href="/login">
-            <Text className="text-sm font-semibold text-primary-600 dark:text-primary-300">
-              Sign in
-            </Text>
-          </Link>
-        </View>
-      </View>
+            <View className="gap-4">
+              <ControllerInput
+                control={control}
+                name="fullName"
+                label="Full name"
+                autoCapitalize="words"
+              />
+              <ControllerInput
+                control={control}
+                name="email"
+                label="Email"
+                autoCapitalize="none"
+                keyboardType="email-address"
+              />
+              <ControllerInput
+                control={control}
+                name="password"
+                label="Password"
+                secureTextEntry
+                textContentType="newPassword"
+              />
+              <ControllerInput
+                control={control}
+                name="confirmPassword"
+                label="Confirm password"
+                secureTextEntry
+                textContentType="newPassword"
+              />
+              <ControllerInput
+                control={control}
+                name="companyCode"
+                label="Company code"
+                autoCapitalize="characters"
+                helperText="Ingresá el código que recibiste. Si lo dejás vacío y completás los datos de tu empresa, generaremos uno automáticamente."
+              />
+              <ControllerInput
+                control={control}
+                name="companyName"
+                label="Company name"
+                autoCapitalize="words"
+                helperText="Obligatorio solo si creás una nueva empresa desde cero."
+              />
+              <ControllerInput
+                control={control}
+                name="countryCode"
+                label="Country (ISO 3166-1)"
+                autoCapitalize="characters"
+                helperText="Ejemplo: AR, US, ES. Obligatorio para crear una nueva empresa."
+              />
+              <ControllerInput
+                control={control}
+                name="defaultTimeZone"
+                label="Default time zone"
+                autoCapitalize="none"
+                helperText="Ejemplo: America/Argentina/Buenos_Aires. Obligatorio para crear una nueva empresa."
+              />
+              <ControllerInput
+                control={control}
+                name="industry"
+                label="Industry"
+                autoCapitalize="words"
+              />
+              <ControllerInput
+                control={control}
+                name="billingEmail"
+                label="Billing email"
+                keyboardType="email-address"
+                autoCapitalize="none"
+              />
+              <ControllerInput
+                control={control}
+                name="companyDescription"
+                label="Company description"
+                inputProps={{ multiline: true, numberOfLines: 3, placeholder: 'Breve descripción' }}
+              />
+            </View>
+
+            <Pressable
+              className={cn(
+                'items-center justify-center rounded-xl bg-primary-600 px-5 py-3',
+                isBusy && 'opacity-60',
+              )}
+              disabled={isBusy}
+              onPress={handleSubmit(onSubmit)}
+            >
+              <Text className="text-base font-semibold text-white">Sign Up</Text>
+            </Pressable>
+
+            <View className="flex-row items-center justify-center gap-1">
+              <Text className="text-sm text-slate-500 dark:text-slate-400">
+                Already have an account?
+              </Text>
+              <Link href="/login">
+                <Text className="text-sm font-semibold text-primary-600 dark:text-primary-300">
+                  Sign in
+                </Text>
+              </Link>
+            </View>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
     </GradientBackground>
   );
 }

--- a/app/(tabs)/(documents)/details.tsx
+++ b/app/(tabs)/(documents)/details.tsx
@@ -1,58 +1,49 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
-import { useEffect, useMemo, useState } from 'react';
-import { LayoutAnimation, Platform, Pressable, ScrollView, Text, View } from 'react-native';
-
+import { useFocusEffect, useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  DOCUMENT_TYPE_LABELS,
-  documentMockData,
-  type DocumentRecord,
-  type DocumentTypeKey,
-} from '@/types/screens/documents';
+  ActivityIndicator,
+  Alert,
+  Platform,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  Text,
+  View,
+  Linking,
+} from 'react-native';
 
-type CollapsibleGroup = {
-  title: string;
-  documents: DocumentRecord[];
-};
+import { useEmployeeDocuments } from '@/hooks/useEmployeeDocuments';
+import type { DocumentRecord, DocumentTypeKey } from '@/types/screens/documents';
+import { DOCUMENT_TYPE_LABELS } from '@/types/screens/documents';
+import type { DocumentStatus } from '@/types/db';
 
 const PRIMARY_COLOR = '#0C6DD9';
 
-const badgeStyles = {
-  signed: { label: 'Firmado', background: '#bbf7d0', color: '#166534' },
+const badgeStyles: Record<DocumentStatus, { label: string; background: string; color: string }> = {
   pending: { label: 'Pendiente', background: '#fef08a', color: '#854d0e' },
+  signed: { label: 'Firmado', background: '#bbf7d0', color: '#166534' },
+  rejected: { label: 'Rechazado', background: '#fecaca', color: '#991b1b' },
+  expired: { label: 'Vencido', background: '#e5e7eb', color: '#4b5563' },
 };
 
-function groupDocuments(type: DocumentTypeKey) {
-  const bucket = documentMockData[type];
-  if (!bucket) {
-    return [] as CollapsibleGroup[];
-  }
-
-  const groupsMap = new Map<string, CollapsibleGroup>();
-
-  for (const doc of bucket.documents) {
-    const key = doc.category ?? 'Otros';
-    if (!groupsMap.has(key)) {
-      groupsMap.set(key, { title: key, documents: [] });
-    }
-    groupsMap.get(key)?.documents.push(doc);
-  }
-
-  if (groupsMap.size === 0) {
-    return [] as CollapsibleGroup[];
-  }
-
-  return Array.from(groupsMap.values());
-}
-
-function DocumentRow({ title, status }: { title: string; status: 'signed' | 'pending' }) {
-  const badge = badgeStyles[status];
+function DocumentRow({
+  document,
+  onPress,
+  isDownloading,
+}: {
+  document: DocumentRecord;
+  onPress: () => void;
+  isDownloading: boolean;
+}) {
+  const badge = badgeStyles[document.status];
 
   return (
     <Pressable
       className="flex-row items-center gap-4 rounded-2xl border border-slate-200 bg-white px-4 py-4"
       android_ripple={{ color: 'rgba(12, 109, 217, 0.12)' }}
-      onPress={() => {}}
+      onPress={onPress}
+      disabled={isDownloading}
     >
       <View className="rounded-xl bg-primary-50 p-3">
         <MaterialIcons
@@ -62,18 +53,45 @@ function DocumentRow({ title, status }: { title: string; status: 'signed' | 'pen
         />
       </View>
       <View className="flex-1">
-        <Text className="text-sm font-semibold text-slate-900">{title}</Text>
+        <Text className="text-sm font-semibold text-slate-900">{document.title}</Text>
+        {document.notes ? (
+          <Text
+            className="mt-1 text-xs text-slate-500"
+            numberOfLines={2}
+          >
+            {document.notes}
+          </Text>
+        ) : null}
+        {document.uploadedAt ? (
+          <Text className="mt-1 text-xs text-slate-400">
+            Subido el {new Date(document.uploadedAt).toLocaleDateString('es-AR')}
+          </Text>
+        ) : null}
       </View>
-      <View
-        className="rounded-xl px-3 py-1"
-        style={{ backgroundColor: badge.background }}
-      >
-        <Text
-          className="text-xs font-semibold uppercase"
-          style={{ color: badge.color }}
+      <View className="items-end gap-2">
+        <View
+          className="rounded-xl px-3 py-1"
+          style={{ backgroundColor: badge.background }}
         >
-          {badge.label}
-        </Text>
+          <Text
+            className="text-xs font-semibold uppercase"
+            style={{ color: badge.color }}
+          >
+            {badge.label}
+          </Text>
+        </View>
+        {isDownloading ? (
+          <ActivityIndicator
+            color={PRIMARY_COLOR}
+            size="small"
+          />
+        ) : (
+          <MaterialIcons
+            name="download"
+            size={20}
+            color={PRIMARY_COLOR}
+          />
+        )}
       </View>
     </Pressable>
   );
@@ -84,6 +102,8 @@ export default function DocumentDetailsScreen() {
   const navigation = useNavigation();
   const params = useLocalSearchParams<{ type?: string }>();
   const type = (params.type ?? 'legajo') as DocumentTypeKey;
+  const { groups, isLoading, error, refresh, downloadDocument } = useEmployeeDocuments();
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
 
   useEffect(() => {
     navigation.setOptions({
@@ -91,31 +111,50 @@ export default function DocumentDetailsScreen() {
     });
   }, [navigation, type]);
 
-  const groupedDocuments = useMemo(() => groupDocuments(type), [type]);
-  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => new Set());
+  useFocusEffect(
+    useCallback(() => {
+      void refresh();
+    }, [refresh]),
+  );
 
-  useEffect(() => {
-    setExpandedGroups(new Set(groupedDocuments.map((group) => group.title)));
-  }, [groupedDocuments]);
+  const documents = useMemo(() => {
+    const group = groups.find((item) => item.key === type);
+    return group?.documents ?? [];
+  }, [groups, type]);
 
-  const toggleGroup = (title: string) => {
-    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-    setExpandedGroups((prev) => {
-      const next = new Set(prev);
-      if (next.has(title)) {
-        next.delete(title);
-      } else {
-        next.add(title);
+  const handleDownload = useCallback(
+    async (record: DocumentRecord) => {
+      try {
+        if (!record.filePath) {
+          Alert.alert('Archivo no disponible', 'Este documento no tiene un archivo adjunto.');
+          return;
+        }
+
+        setDownloadingId(record.id);
+        const url = await downloadDocument(record);
+        await Linking.openURL(url);
+      } catch (err) {
+        console.error('[DocumentDetailsScreen] download error', err);
+        Alert.alert('Error', 'No pudimos descargar el documento. Intenta nuevamente.');
+      } finally {
+        setDownloadingId(null);
       }
-      return next;
-    });
-  };
+    },
+    [downloadDocument],
+  );
 
-  const hasDocuments = groupedDocuments.length > 0;
+  const hasDocuments = documents.length > 0;
 
   return (
     <View className="flex-1 bg-slate-100">
       <ScrollView
+        refreshControl={
+          <RefreshControl
+            refreshing={isLoading}
+            onRefresh={refresh}
+            tintColor={PRIMARY_COLOR}
+          />
+        }
         contentContainerStyle={{
           paddingHorizontal: 24,
           paddingBottom: 48,
@@ -124,40 +163,15 @@ export default function DocumentDetailsScreen() {
         showsVerticalScrollIndicator={false}
       >
         {hasDocuments ? (
-          <View className="gap-4">
-            {groupedDocuments.map((group) => {
-              const isExpanded = expandedGroups.has(group.title);
-              return (
-                <View
-                  key={group.title}
-                  className="overflow-hidden rounded-3xl bg-white"
-                >
-                  <Pressable
-                    className="flex-row items-center justify-between px-5 py-4"
-                    android_ripple={{ color: 'rgba(12, 109, 217, 0.12)' }}
-                    onPress={() => toggleGroup(group.title)}
-                  >
-                    <Text className="text-base font-semibold text-slate-900">{group.title}</Text>
-                    <MaterialIcons
-                      name={isExpanded ? 'expand-less' : 'expand-more'}
-                      size={26}
-                      color={PRIMARY_COLOR}
-                    />
-                  </Pressable>
-                  {isExpanded ? (
-                    <View className="gap-3 border-t border-slate-100 bg-slate-50 px-4 py-4">
-                      {group.documents.map((doc) => (
-                        <DocumentRow
-                          key={doc.id}
-                          title={doc.title}
-                          status={doc.status}
-                        />
-                      ))}
-                    </View>
-                  ) : null}
-                </View>
-              );
-            })}
+          <View className="gap-3">
+            {documents.map((doc) => (
+              <DocumentRow
+                key={doc.id}
+                document={doc}
+                isDownloading={downloadingId === doc.id}
+                onPress={() => handleDownload(doc)}
+              />
+            ))}
           </View>
         ) : (
           <View className="items-center gap-4 rounded-3xl bg-white px-6 py-12">
@@ -179,6 +193,12 @@ export default function DocumentDetailsScreen() {
             </Pressable>
           </View>
         )}
+
+        {error ? (
+          <View className="mt-6 rounded-3xl bg-white px-5 py-4">
+            <Text className="text-sm text-rose-500">{error}</Text>
+          </View>
+        ) : null}
       </ScrollView>
     </View>
   );

--- a/app/(tabs)/(documents)/details.tsx
+++ b/app/(tabs)/(documents)/details.tsx
@@ -50,7 +50,7 @@ function DocumentRow({ title, status }: { title: string; status: 'signed' | 'pen
 
   return (
     <Pressable
-      className="flex-row items-center gap-4 rounded-2xl border border-slate-200 bg-white px-4 py-4 shadow-sm"
+      className="flex-row items-center gap-4 rounded-2xl border border-slate-200 bg-white px-4 py-4"
       android_ripple={{ color: 'rgba(12, 109, 217, 0.12)' }}
       onPress={() => {}}
     >
@@ -130,7 +130,7 @@ export default function DocumentDetailsScreen() {
               return (
                 <View
                   key={group.title}
-                  className="overflow-hidden rounded-3xl bg-white shadow-sm"
+                  className="overflow-hidden rounded-3xl bg-white"
                 >
                   <Pressable
                     className="flex-row items-center justify-between px-5 py-4"
@@ -160,7 +160,7 @@ export default function DocumentDetailsScreen() {
             })}
           </View>
         ) : (
-          <View className="items-center gap-4 rounded-3xl bg-white px-6 py-12 shadow-sm">
+          <View className="items-center gap-4 rounded-3xl bg-white px-6 py-12">
             <MaterialIcons
               name="insert-drive-file"
               size={64}

--- a/app/(tabs)/(documents)/details.tsx
+++ b/app/(tabs)/(documents)/details.tsx
@@ -1,6 +1,6 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { useFocusEffect, useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -13,6 +13,7 @@ import {
   Linking,
 } from 'react-native';
 
+import { Skeleton } from '@/components/Skeleton';
 import { useEmployeeDocuments } from '@/hooks/useEmployeeDocuments';
 import type { DocumentRecord, DocumentTypeKey } from '@/types/screens/documents';
 import { DOCUMENT_TYPE_LABELS } from '@/types/screens/documents';
@@ -97,13 +98,31 @@ function DocumentRow({
   );
 }
 
+function DocumentRowSkeleton() {
+  return (
+    <View className="flex-row items-center gap-4 rounded-2xl border border-slate-200 bg-white px-4 py-4">
+      <Skeleton className="h-12 w-12 rounded-xl" />
+      <View className="flex-1 gap-2">
+        <Skeleton className="h-4 w-40 rounded-full" />
+        <Skeleton className="h-3 w-48 rounded-full" />
+        <Skeleton className="h-3 w-32 rounded-full" />
+      </View>
+      <View className="items-end gap-2">
+        <Skeleton className="h-6 w-16 rounded-full" />
+        <Skeleton className="h-5 w-5 rounded-full" />
+      </View>
+    </View>
+  );
+}
+
 export default function DocumentDetailsScreen() {
   const router = useRouter();
   const navigation = useNavigation();
   const params = useLocalSearchParams<{ type?: string }>();
   const type = (params.type ?? 'legajo') as DocumentTypeKey;
-  const { groups, isLoading, error, refresh, downloadDocument } = useEmployeeDocuments();
+  const { groups, hasLoaded, isLoading, error, refresh, downloadDocument } = useEmployeeDocuments();
   const [downloadingId, setDownloadingId] = useState<string | null>(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
 
   useEffect(() => {
     navigation.setOptions({
@@ -111,8 +130,15 @@ export default function DocumentDetailsScreen() {
     });
   }, [navigation, type]);
 
+  const hasHandledInitialFocus = useRef(false);
+
   useFocusEffect(
     useCallback(() => {
+      if (!hasHandledInitialFocus.current) {
+        hasHandledInitialFocus.current = true;
+        return;
+      }
+
       void refresh();
     }, [refresh]),
   );
@@ -144,14 +170,31 @@ export default function DocumentDetailsScreen() {
   );
 
   const hasDocuments = documents.length > 0;
+  const showSkeleton = !hasLoaded || (isLoading && !hasDocuments);
+  const showEmptyState = hasLoaded && !isLoading && !hasDocuments;
+
+  const handleRefreshControl = useCallback(async () => {
+    if (isRefreshing) {
+      return;
+    }
+
+    setIsRefreshing(true);
+    try {
+      await refresh();
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [isRefreshing, refresh]);
 
   return (
     <View className="flex-1 bg-slate-100">
       <ScrollView
         refreshControl={
           <RefreshControl
-            refreshing={isLoading}
-            onRefresh={refresh}
+            refreshing={isRefreshing}
+            onRefresh={() => {
+              void handleRefreshControl();
+            }}
             tintColor={PRIMARY_COLOR}
           />
         }
@@ -162,7 +205,13 @@ export default function DocumentDetailsScreen() {
         }}
         showsVerticalScrollIndicator={false}
       >
-        {hasDocuments ? (
+        {showSkeleton ? (
+          <View className="gap-3">
+            {[0, 1, 2].map((item) => (
+              <DocumentRowSkeleton key={item} />
+            ))}
+          </View>
+        ) : hasDocuments ? (
           <View className="gap-3">
             {documents.map((doc) => (
               <DocumentRow
@@ -173,7 +222,7 @@ export default function DocumentDetailsScreen() {
               />
             ))}
           </View>
-        ) : (
+        ) : showEmptyState ? (
           <View className="items-center gap-4 rounded-3xl bg-white px-6 py-12">
             <MaterialIcons
               name="insert-drive-file"
@@ -192,7 +241,7 @@ export default function DocumentDetailsScreen() {
               <Text className="text-sm font-semibold text-primary-700">Volver</Text>
             </Pressable>
           </View>
-        )}
+        ) : null}
 
         {error ? (
           <View className="mt-6 rounded-3xl bg-white px-5 py-4">

--- a/app/(tabs)/(documents)/index.tsx
+++ b/app/(tabs)/(documents)/index.tsx
@@ -20,7 +20,7 @@ export default function DocumentsScreen() {
         contentContainerStyle={{ paddingBottom: 120 }}
         showsVerticalScrollIndicator={false}
       >
-        <View className="rounded-b-[32px] bg-primary-600 px-6 pb-14 pt-6 shadow-md">
+        <View className="rounded-b-[32px] bg-primary-600 px-6 pb-14 pt-6">
           <Text className="text-2xl font-semibold text-white">Carpetas</Text>
           <Text className="mt-2 text-sm text-primary-100">
             Revisa tus documentos organizados por categoría.
@@ -32,7 +32,7 @@ export default function DocumentsScreen() {
             <Fragment key={key}>
               <Pressable
                 accessibilityRole="button"
-                className="mb-3 overflow-hidden rounded-3xl bg-white shadow-sm"
+                className="mb-3 overflow-hidden rounded-3xl bg-white"
                 android_ripple={{ color: 'rgba(12, 109, 217, 0.12)' }}
                 onPress={() =>
                   router.push({
@@ -72,7 +72,7 @@ export default function DocumentsScreen() {
       <Pressable
         accessibilityLabel="Agregar documento"
         accessibilityRole="button"
-        className="absolute bottom-8 right-6 h-14 w-14 items-center justify-center rounded-full bg-primary-600 shadow-lg"
+        className="absolute bottom-8 right-6 h-14 w-14 items-center justify-center rounded-full bg-primary-600"
         onPress={() => router.push('/(tabs)/(documents)/upload')}
       >
         <MaterialIcons

--- a/app/(tabs)/(documents)/index.tsx
+++ b/app/(tabs)/(documents)/index.tsx
@@ -1,9 +1,10 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { useRouter } from 'expo-router';
-import { Fragment } from 'react';
-import { Pressable, ScrollView, Text, View } from 'react-native';
+import { useFocusEffect, useRouter } from 'expo-router';
+import { Fragment, useCallback } from 'react';
+import { ActivityIndicator, Pressable, RefreshControl, ScrollView, Text, View } from 'react-native';
 
-import { DOCUMENT_TYPE_LABELS, documentMockData } from '@/types/screens/documents';
+import { useEmployeeDocuments } from '@/hooks/useEmployeeDocuments';
+import { DOCUMENT_TYPE_LABELS } from '@/types/screens/documents';
 
 const PRIMARY_COLOR = '#0C6DD9';
 
@@ -13,10 +14,24 @@ function formatCount(count: number) {
 
 export default function DocumentsScreen() {
   const router = useRouter();
+  const { groups, isLoading, error, refresh } = useEmployeeDocuments();
+
+  useFocusEffect(
+    useCallback(() => {
+      void refresh();
+    }, [refresh]),
+  );
 
   return (
     <View className="flex-1 bg-slate-100">
       <ScrollView
+        refreshControl={
+          <RefreshControl
+            refreshing={isLoading}
+            onRefresh={refresh}
+            tintColor={PRIMARY_COLOR}
+          />
+        }
         contentContainerStyle={{ paddingBottom: 120 }}
         showsVerticalScrollIndicator={false}
       >
@@ -28,8 +43,8 @@ export default function DocumentsScreen() {
         </View>
 
         <View className="-mt-8 px-6">
-          {Object.entries(documentMockData).map(([key, group]) => (
-            <Fragment key={key}>
+          {groups.map((group) => (
+            <Fragment key={group.key}>
               <Pressable
                 accessibilityRole="button"
                 className="mb-3 overflow-hidden rounded-3xl bg-white"
@@ -37,7 +52,7 @@ export default function DocumentsScreen() {
                 onPress={() =>
                   router.push({
                     pathname: '/(tabs)/(documents)/details',
-                    params: { type: key },
+                    params: { type: group.key },
                   })
                 }
               >
@@ -51,7 +66,7 @@ export default function DocumentsScreen() {
                   </View>
                   <View className="flex-1">
                     <Text className="text-base font-semibold text-slate-900">
-                      {DOCUMENT_TYPE_LABELS[key as keyof typeof DOCUMENT_TYPE_LABELS]}
+                      {DOCUMENT_TYPE_LABELS[group.key]}
                     </Text>
                     <Text className="mt-1 text-sm text-slate-500">
                       {formatCount(group.documents.length)}
@@ -66,6 +81,33 @@ export default function DocumentsScreen() {
               </Pressable>
             </Fragment>
           ))}
+
+          {error ? (
+            <View className="mt-6 rounded-3xl bg-white px-5 py-4">
+              <Text className="text-sm text-rose-500">{error}</Text>
+            </View>
+          ) : null}
+
+          {groups.every((group) => group.documents.length === 0) && !isLoading ? (
+            <View className="mt-6 items-center gap-3 rounded-3xl bg-white px-6 py-10">
+              <MaterialIcons
+                name="insert-drive-file"
+                size={48}
+                color={PRIMARY_COLOR}
+              />
+              <Text className="text-base font-semibold text-slate-900">Sin documentos aún</Text>
+              <Text className="text-center text-sm text-slate-500">
+                Cuando cargues documentos o tu empresa los comparta, aparecerán aquí.
+              </Text>
+            </View>
+          ) : null}
+
+          {isLoading ? (
+            <View className="mt-6 flex-row items-center justify-center gap-3">
+              <ActivityIndicator color={PRIMARY_COLOR} />
+              <Text className="text-sm text-slate-500">Actualizando documentos…</Text>
+            </View>
+          ) : null}
         </View>
       </ScrollView>
 

--- a/app/(tabs)/(documents)/index.tsx
+++ b/app/(tabs)/(documents)/index.tsx
@@ -1,8 +1,9 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { useFocusEffect, useRouter } from 'expo-router';
-import { Fragment, useCallback } from 'react';
+import { Fragment, useCallback, useState } from 'react';
 import { ActivityIndicator, Pressable, RefreshControl, ScrollView, Text, View } from 'react-native';
 
+import { Skeleton } from '@/components/Skeleton';
 import { useEmployeeDocuments } from '@/hooks/useEmployeeDocuments';
 import { DOCUMENT_TYPE_LABELS } from '@/types/screens/documents';
 
@@ -14,7 +15,8 @@ function formatCount(count: number) {
 
 export default function DocumentsScreen() {
   const router = useRouter();
-  const { groups, isLoading, error, refresh } = useEmployeeDocuments();
+  const { groups, hasLoaded, isLoading, error, refresh } = useEmployeeDocuments();
+  const [isRefreshing, setIsRefreshing] = useState(false);
 
   useFocusEffect(
     useCallback(() => {
@@ -22,13 +24,28 @@ export default function DocumentsScreen() {
     }, [refresh]),
   );
 
+  const handleRefresh = useCallback(async () => {
+    if (isRefreshing) {
+      return;
+    }
+
+    setIsRefreshing(true);
+    try {
+      await refresh();
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [isRefreshing, refresh]);
+
   return (
-    <View className="flex-1 bg-slate-100">
+    <View>
       <ScrollView
         refreshControl={
           <RefreshControl
-            refreshing={isLoading}
-            onRefresh={refresh}
+            refreshing={isRefreshing}
+            onRefresh={() => {
+              void handleRefresh();
+            }}
             tintColor={PRIMARY_COLOR}
           />
         }
@@ -68,9 +85,13 @@ export default function DocumentsScreen() {
                     <Text className="text-base font-semibold text-slate-900">
                       {DOCUMENT_TYPE_LABELS[group.key]}
                     </Text>
-                    <Text className="mt-1 text-sm text-slate-500">
-                      {formatCount(group.documents.length)}
-                    </Text>
+                    {!hasLoaded || isLoading ? (
+                      <Skeleton className="mt-1 h-3 w-24 rounded-full" />
+                    ) : (
+                      <Text className="mt-1 text-sm text-slate-500">
+                        {formatCount(group.documents.length)}
+                      </Text>
+                    )}
                   </View>
                   <MaterialIcons
                     name="chevron-right"
@@ -88,7 +109,7 @@ export default function DocumentsScreen() {
             </View>
           ) : null}
 
-          {groups.every((group) => group.documents.length === 0) && !isLoading ? (
+          {hasLoaded && !isLoading && groups.every((group) => group.documents.length === 0) ? (
             <View className="mt-6 items-center gap-3 rounded-3xl bg-white px-6 py-10">
               <MaterialIcons
                 name="insert-drive-file"

--- a/app/(tabs)/(documents)/upload.tsx
+++ b/app/(tabs)/(documents)/upload.tsx
@@ -273,7 +273,7 @@ export default function UploadDocumentScreen() {
           </View>
 
           <View className="mt-4 px-6">
-            <View className="items-center rounded-3xl bg-white px-6 py-8 shadow-sm">
+            <View className="items-center rounded-3xl bg-white px-6 py-8">
               {selectedFile ? (
                 selectedFile.isImage ? (
                   <Image
@@ -357,7 +357,7 @@ export default function UploadDocumentScreen() {
                       Tipo de documento
                     </Text>
                     <Pressable
-                      className="mt-2 flex-row items-center justify-between rounded-2xl border border-slate-200 bg-white px-4 py-4 shadow-sm"
+                      className="mt-2 flex-row items-center justify-between rounded-2xl border border-slate-200 bg-white px-4 py-4"
                       onPress={() => setTypeModalVisible(true)}
                     >
                       <Text className="text-sm font-medium text-slate-900">
@@ -389,7 +389,7 @@ export default function UploadDocumentScreen() {
                       Observaciones (opcional)
                     </Text>
                     <TextInput
-                      className="mt-2 min-h-[112px] rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm"
+                      className="mt-2 min-h-[112px] rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900"
                       placeholder="Escribe un mensaje para tu empleador"
                       placeholderTextColor="#94a3b8"
                       multiline

--- a/app/(tabs)/(documents)/upload.tsx
+++ b/app/(tabs)/(documents)/upload.tsx
@@ -1,11 +1,13 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as DocumentPicker from 'expo-document-picker';
+import * as FileSystem from 'expo-file-system';
 import * as ImagePicker from 'expo-image-picker';
 import { useRouter } from 'expo-router';
 import { useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import {
+  ActivityIndicator,
   Alert,
   Image,
   KeyboardAvoidingView,
@@ -21,6 +23,10 @@ import {
 import { z } from 'zod';
 
 import { PermissionModal } from '@/components/custom/PermissionModal';
+import { useAuth } from '@/hooks/useAuth';
+import { useEmployeeContext } from '@/hooks/useEmployeeContext';
+import { createDocument, uploadDocumentFile } from '@/lib/repositories';
+import type { DocumentInsert } from '@/types/db';
 import {
   DOCUMENT_TYPE_KEYS,
   DOCUMENT_TYPES,
@@ -44,6 +50,14 @@ const uploadSchema = z.object({
 
 export default function UploadDocumentScreen() {
   const router = useRouter();
+  const { user } = useAuth();
+  const {
+    companyId,
+    employeeId,
+    membership,
+    isLoading: isContextLoading,
+    error: contextError,
+  } = useEmployeeContext();
   const [selectedFile, setSelectedFile] = useState<SelectedFile | null>(null);
   const [permissionPrompt, setPermissionPrompt] = useState<PermissionPrompt | null>(null);
   const [typeModalVisible, setTypeModalVisible] = useState(false);
@@ -219,11 +233,91 @@ export default function UploadDocumentScreen() {
   };
 
   const onSubmit = async (values: UploadFormValues) => {
-    await new Promise((resolve) => setTimeout(resolve, 400));
-    Alert.alert('Documento enviado', 'Tu documento fue cargado satisfactoriamente.');
-    reset();
-    setSelectedFile(null);
-    router.back();
+    if (!companyId) {
+      Alert.alert('No se pudo enviar', 'No encontramos una compañía asociada a tu usuario.');
+      return;
+    }
+    console.log('employeeId', employeeId);
+
+    if (!employeeId) {
+      Alert.alert(
+        'Perfil faltante',
+        'Tu perfil de empleado no está disponible. Comunícate con tu administrador para habilitarlo antes de subir documentos.',
+      );
+      return;
+    }
+
+    if (!selectedFile) {
+      Alert.alert('Adjunta un archivo', 'Selecciona un archivo para continuar.');
+      return;
+    }
+
+    try {
+      const fileInfo = await FileSystem.getInfoAsync(selectedFile.uri);
+      const base64 = await FileSystem.readAsStringAsync(selectedFile.uri, {
+        encoding: FileSystem.EncodingType.Base64,
+      });
+      const fileBytes = decodeBase64ToUint8Array(base64);
+      const fileData = fileBytes.buffer.slice(
+        fileBytes.byteOffset,
+        fileBytes.byteOffset + fileBytes.byteLength,
+      );
+      const fileSize = typeof fileInfo.size === 'number' ? fileInfo.size : fileBytes.byteLength;
+      const notes = values.notes?.trim() ? values.notes.trim() : null;
+      const metadata = {
+        categoryKey: values.documentType,
+        notes,
+        originalFileName: selectedFile.name,
+        uploadedFrom: 'mobile-app',
+      } satisfies Record<string, unknown>;
+
+      const now = new Date().toISOString();
+      const documentPayload: DocumentInsert = {
+        company_id: companyId,
+        template_id: null,
+        employee_id: employeeId,
+        title: selectedFile.name,
+        status: 'pending',
+        issued_at: now,
+        due_at: null,
+        signed_at: null,
+        signed_by: null,
+        rejected_at: null,
+        rejected_reason: null,
+        expired_at: null,
+        metadata,
+        created_by: user?.id ?? membership?.user_id ?? null,
+        updated_at: now,
+      };
+
+      const document = await createDocument(companyId, documentPayload);
+
+      const contentType = selectedFile.mimeType ?? 'application/octet-stream';
+
+      await uploadDocumentFile({
+        companyId,
+        documentId: document.id,
+        uploadedBy: user?.id ?? membership?.user_id ?? null,
+        file: fileData,
+        fileName: selectedFile.name,
+        contentType,
+        fileSize,
+        storageOptions: {
+          cacheControl: '3600',
+        },
+      });
+
+      Alert.alert('Documento enviado', 'Tu documento fue cargado satisfactoriamente.');
+      reset();
+      setSelectedFile(null);
+      router.back();
+    } catch (error) {
+      console.error('[UploadDocumentScreen] Failed to upload document', error);
+      Alert.alert(
+        'Ocurrió un error',
+        'No pudimos subir tu documento. Intenta nuevamente en unos minutos.',
+      );
+    }
   };
 
   const permissionCopy = useMemo(() => {
@@ -409,14 +503,23 @@ export default function UploadDocumentScreen() {
             </View>
 
             <Pressable
-              className={`mt-8 rounded-full bg-primary-600 px-6 py-4 ${isSubmitting ? 'opacity-60' : ''}`}
-              disabled={isSubmitting}
+              className={`mt-8 rounded-full bg-primary-600 px-6 py-4 ${
+                isSubmitting || isContextLoading ? 'opacity-60' : ''
+              }`}
+              disabled={isSubmitting || isContextLoading}
               onPress={handleSubmit(onSubmit)}
             >
-              <Text className="text-center text-base font-semibold uppercase text-white">
-                Enviar
-              </Text>
+              {isSubmitting || isContextLoading ? (
+                <ActivityIndicator color="#ffffff" />
+              ) : (
+                <Text className="text-center text-base font-semibold uppercase text-white">
+                  Enviar
+                </Text>
+              )}
             </Pressable>
+            {contextError ? (
+              <Text className="mt-4 text-center text-xs text-rose-500">{contextError}</Text>
+            ) : null}
           </View>
         </ScrollView>
       </KeyboardAvoidingView>
@@ -441,6 +544,40 @@ export default function UploadDocumentScreen() {
     </View>
   );
 }
+
+const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+
+const decodeBase64ToUint8Array = (base64: string): Uint8Array => {
+  const clean = base64.replace(/[^A-Za-z0-9+/=]/g, '');
+  const padding = clean.endsWith('==') ? 2 : clean.endsWith('=') ? 1 : 0;
+  const length = (clean.length * 3) / 4 - padding;
+  const bytes = new Uint8Array(length);
+
+  let byteIndex = 0;
+
+  for (let i = 0; i < clean.length; i += 4) {
+    const enc1 = BASE64_ALPHABET.indexOf(clean[i]);
+    const enc2 = BASE64_ALPHABET.indexOf(clean[i + 1]);
+    const enc3Char = clean[i + 2] ?? '=';
+    const enc4Char = clean[i + 3] ?? '=';
+    const enc3 = enc3Char === '=' ? 64 : BASE64_ALPHABET.indexOf(enc3Char);
+    const enc4 = enc4Char === '=' ? 64 : BASE64_ALPHABET.indexOf(enc4Char);
+
+    const chunk = (enc1 << 18) | (enc2 << 12) | ((enc3 & 63) << 6) | (enc4 & 63);
+
+    bytes[byteIndex++] = (chunk >> 16) & 0xff;
+
+    if (enc3 !== 64 && byteIndex < length) {
+      bytes[byteIndex++] = (chunk >> 8) & 0xff;
+    }
+
+    if (enc4 !== 64 && byteIndex < length) {
+      bytes[byteIndex++] = chunk & 0xff;
+    }
+  }
+
+  return bytes;
+};
 
 function DocumentTypeModal({
   visible,

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -25,7 +25,8 @@ export default function HomeScreen() {
   const toUpper = (value?: string | null) => (value ? value.toUpperCase() : undefined);
   const greetingName = toUpper(user?.firstName) ?? 'USUARIO';
   const formattedFullName = user
-    ? [toUpper(user?.lastName), toUpper(user?.firstName)].filter(Boolean).join(', ') || 'Usuario Invitado'
+    ? [toUpper(user?.lastName), toUpper(user?.firstName)].filter(Boolean).join(', ') ||
+      'Usuario Invitado'
     : 'Usuario Invitado';
 
   return (
@@ -34,7 +35,7 @@ export default function HomeScreen() {
       contentContainerStyle={{ paddingBottom: 32 }}
       showsVerticalScrollIndicator={false}
     >
-      <View className="rounded-b-[32px] bg-primary-600 px-6 pb-12 pt-2 shadow-lg">
+      <View className="rounded-b-[32px] bg-primary-600 px-6 pb-12 pt-2">
         <Text className="mt-10 text-2xl font-semibold uppercase text-white">
           ¡Bienvenido {greetingName}!
         </Text>
@@ -44,7 +45,7 @@ export default function HomeScreen() {
       </View>
 
       <View className="-mt-10 px-6">
-        <View className="rounded-3xl bg-white p-5 shadow-xl">
+        <View className="rounded-3xl bg-white p-5">
           <View className="flex-row items-center">
             <View className="rounded-full bg-primary-100 p-4">
               <MaterialIcons
@@ -74,10 +75,7 @@ export default function HomeScreen() {
           {pendingCards.map((card, index) => (
             <View
               key={card.id}
-              className={cn(
-                'flex-row items-center rounded-3xl bg-white p-5 shadow-sm',
-                index > 0 && 'mt-4',
-              )}
+              className={cn('flex-row items-center rounded-3xl bg-white p-5', index > 0 && 'mt-4')}
             >
               <View className="rounded-full border border-primary-200 p-3">
                 <MaterialIcons
@@ -94,7 +92,7 @@ export default function HomeScreen() {
           ))}
         </View>
 
-        <View className="mt-5 items-center rounded-3xl bg-white px-6 py-10 shadow-sm">
+        <View className="mt-5 items-center rounded-3xl bg-white px-6 py-10">
           <View className="rounded-full bg-primary-100 p-4">
             <MaterialIcons
               name="mark-email-read"
@@ -119,9 +117,7 @@ export default function HomeScreen() {
                 await signOut();
               } catch (error) {
                 const message =
-                  error instanceof Error
-                    ? error.message
-                    : 'No pudimos cerrar tu sesión.';
+                  error instanceof Error ? error.message : 'No pudimos cerrar tu sesión.';
                 Alert.alert('Error al cerrar sesión', message);
               }
             })();

--- a/app/(tabs)/(paychecks)/index.tsx
+++ b/app/(tabs)/(paychecks)/index.tsx
@@ -133,7 +133,7 @@ export default function PaychecksScreen() {
         contentContainerStyle={{ paddingBottom: 120 }}
         showsVerticalScrollIndicator={false}
       >
-        <View className="rounded-b-[32px] bg-primary-600 px-6 pb-14 pt-6 shadow-md">
+        <View className="rounded-b-[32px] bg-primary-600 px-6 pb-14 pt-6">
           <Text className="mt-2 text-sm text-primary-100">
             Visualiza y descarga tus recibos por período.
           </Text>
@@ -146,7 +146,7 @@ export default function PaychecksScreen() {
             return (
               <View
                 key={group.year}
-                className="mb-4 overflow-hidden rounded-3xl bg-white shadow-sm"
+                className="mb-4 overflow-hidden rounded-3xl bg-white"
               >
                 <Pressable
                   accessibilityRole="button"

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -55,8 +55,7 @@ export default function TabLayout() {
           headerStyle: {
             backgroundColor: palette.tint,
             borderBottomWidth: 0,
-            elevation: 0,
-            shadowOpacity: 0,
+            boxShadow: 'none',
           },
           headerTitleStyle: {
             fontSize: 20,
@@ -148,8 +147,7 @@ export default function TabLayout() {
           try {
             await signOut();
           } catch (error) {
-            const message =
-              error instanceof Error ? error.message : 'No pudimos cerrar tu sesión.';
+            const message = error instanceof Error ? error.message : 'No pudimos cerrar tu sesión.';
             Alert.alert('Error al cerrar sesión', message);
           }
         }}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -26,8 +26,7 @@ function AuthGate() {
       {isAuthLoading ? (
         <Center
           bg={colorScheme === 'dark' ? '$backgroundDark950' : '$backgroundLight0'}
-          style={StyleSheet.absoluteFill}
-          pointerEvents="auto"
+          style={[StyleSheet.absoluteFill, { pointerEvents: 'auto' }]}
         >
           <Spinner size="large" />
         </Center>

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,0 +1,582 @@
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'expo-router';
+import { useMemo, useState, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native';
+
+import { ControllerInput } from '@/components/custom/ControllerInput';
+import { useAuth } from '@/hooks/useAuth';
+import { supabase } from '@/lib/supabase';
+import { profileFormSchema, companyFormSchema } from '@/types/screens/settings';
+import type { ProfileFormValues, CompanyFormValues } from '@/types/screens/settings';
+
+type CompanyState = {
+  id: string;
+  name: string;
+  companyCode: string;
+  countryCode: string;
+  defaultTimeZone: string;
+  planTier: string;
+  description?: string | null;
+  industry?: string | null;
+  billingEmail?: string | null;
+  role?: string;
+  status?: string;
+};
+
+const PRIMARY_COLOR = '#0C6DD9';
+
+export default function SettingsScreen() {
+  const { user, refreshSession } = useAuth();
+  const [isBootstrapping, setIsBootstrapping] = useState(true);
+  const [isSavingProfile, setIsSavingProfile] = useState(false);
+  const [isSavingCompany, setIsSavingCompany] = useState(false);
+  const [company, setCompany] = useState<CompanyState | null>(null);
+  const router = useRouter();
+  const canGoBack = router.canGoBack();
+
+  const profileForm = useForm<ProfileFormValues>({
+    resolver: zodResolver(profileFormSchema),
+    defaultValues: {
+      fullName: '',
+      preferredName: undefined,
+      phone: undefined,
+      timeZone: 'UTC',
+      locale: 'es-AR',
+      bio: undefined,
+      cuil: undefined,
+    },
+  });
+
+  const companyForm = useForm<CompanyFormValues>({
+    resolver: zodResolver(companyFormSchema),
+    defaultValues: {
+      companyCode: '',
+      companyName: undefined,
+      countryCode: undefined,
+      defaultTimeZone: undefined,
+      industry: undefined,
+      billingEmail: undefined,
+      description: undefined,
+    },
+  });
+
+  const fullNameFromAuth = useMemo(() => {
+    if (!user) {
+      return '';
+    }
+    const parts = [user.firstName, user.lastName].filter(Boolean) as string[];
+    return parts.length ? parts.join(' ') : '';
+  }, [user]);
+
+  useEffect(() => {
+    if (!user?.id) {
+      setIsBootstrapping(false);
+      return;
+    }
+
+    const load = async () => {
+      setIsBootstrapping(true);
+      try {
+        const [
+          { data: profileData, error: profileError },
+          { data: membershipData, error: membershipError },
+        ] = await Promise.all([
+          supabase.from('user_profiles').select('*').eq('user_id', user.id).maybeSingle(),
+          supabase
+            .from('company_members')
+            .select(
+              'id, status, role, company:companies(id, name, company_code, country_code, default_time_zone, plan_tier, industry, billing_email, metadata)',
+            )
+            .eq('user_id', user.id)
+            .maybeSingle(),
+        ]);
+
+        if (profileError) {
+          console.warn('[Settings] Failed to load profile', profileError);
+        }
+
+        if (membershipError) {
+          console.warn('[Settings] Failed to load membership', membershipError);
+        }
+
+        const defaults: ProfileFormValues = {
+          fullName: profileData?.full_name ?? fullNameFromAuth,
+          preferredName: profileData?.preferred_name ?? undefined,
+          phone: profileData?.phone ?? undefined,
+          timeZone: profileData?.time_zone ?? 'UTC',
+          locale: profileData?.locale ?? 'es-AR',
+          bio: profileData?.bio ?? undefined,
+          cuil: user?.cuil ?? undefined,
+        };
+
+        profileForm.reset(defaults);
+
+        if (membershipData?.company) {
+          const companyMetadata = (membershipData.company.metadata ?? {}) as Record<
+            string,
+            unknown
+          >;
+          const description =
+            typeof companyMetadata.description === 'string'
+              ? companyMetadata.description
+              : undefined;
+
+          const resolvedCompany: CompanyState = {
+            id: membershipData.company.id,
+            name: membershipData.company.name,
+            companyCode: membershipData.company.company_code,
+            countryCode: membershipData.company.country_code,
+            defaultTimeZone: membershipData.company.default_time_zone,
+            planTier: membershipData.company.plan_tier,
+            description: description ?? null,
+            industry: membershipData.company.industry,
+            billingEmail: membershipData.company.billing_email,
+            role: membershipData.role ?? undefined,
+            status: membershipData.status ?? undefined,
+          };
+
+          setCompany(resolvedCompany);
+          companyForm.reset({
+            companyCode: resolvedCompany.companyCode,
+            companyName: resolvedCompany.name,
+            countryCode: resolvedCompany.countryCode,
+            defaultTimeZone: resolvedCompany.defaultTimeZone,
+            industry: resolvedCompany.industry ?? undefined,
+            billingEmail: resolvedCompany.billingEmail ?? undefined,
+            description: resolvedCompany.description ?? undefined,
+          });
+        } else {
+          setCompany(null);
+          companyForm.reset({
+            companyCode: '',
+            companyName: undefined,
+            countryCode: undefined,
+            defaultTimeZone: undefined,
+            industry: undefined,
+            billingEmail: undefined,
+            description: undefined,
+          });
+        }
+      } finally {
+        setIsBootstrapping(false);
+      }
+    };
+
+    void load();
+  }, [companyForm, profileForm, fullNameFromAuth, user]);
+
+  const onSubmitProfile = profileForm.handleSubmit(async (values) => {
+    if (!user?.id) {
+      return;
+    }
+
+    setIsSavingProfile(true);
+    try {
+      const normalized = {
+        full_name: values.fullName.trim(),
+        preferred_name: values.preferredName ?? null,
+        phone: values.phone ?? null,
+        time_zone: values.timeZone.trim(),
+        locale: values.locale.trim(),
+        bio: values.bio ?? null,
+        user_id: user.id,
+        updated_at: new Date().toISOString(),
+      };
+
+      const { error: upsertError } = await supabase.from('user_profiles').upsert(normalized, {
+        onConflict: 'user_id',
+      });
+
+      if (upsertError) {
+        throw new Error(upsertError.message);
+      }
+
+      const { error: updateUserError } = await supabase.auth.updateUser({
+        data: {
+          fullName: values.fullName.trim(),
+          preferredName: values.preferredName ?? null,
+          phone: values.phone ?? null,
+          timeZone: values.timeZone.trim(),
+          locale: values.locale.trim(),
+          bio: values.bio ?? null,
+          cuil: values.cuil ?? null,
+        },
+      });
+
+      if (updateUserError) {
+        throw new Error(updateUserError.message);
+      }
+
+      await refreshSession();
+
+      Alert.alert('Perfil actualizado', 'Guardamos tus datos personales.');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'No pudimos guardar los cambios.';
+      Alert.alert('Error al guardar', message);
+    } finally {
+      setIsSavingProfile(false);
+    }
+  });
+
+  const onSubmitCompany = companyForm.handleSubmit(async (values) => {
+    if (!user?.id) {
+      return;
+    }
+
+    setIsSavingCompany(true);
+    try {
+      const trimmedCode = values.companyCode.trim().toUpperCase();
+
+      const { data: companyMatch, error: companyFetchError } = await supabase
+        .from('companies')
+        .select('*')
+        .eq('company_code', trimmedCode)
+        .maybeSingle();
+
+      if (companyFetchError) {
+        throw new Error(companyFetchError.message);
+      }
+
+      let resolvedCompany = companyMatch;
+
+      if (!resolvedCompany) {
+        if (!values.companyName || !values.countryCode || !values.defaultTimeZone) {
+          throw new Error(
+            'Para crear una empresa nueva completá el nombre, el país (ISO 3166-1) y el huso horario por defecto.',
+          );
+        }
+
+        const payload = {
+          name: values.companyName,
+          company_code: trimmedCode,
+          country_code: values.countryCode,
+          default_time_zone: values.defaultTimeZone,
+          plan_tier: 'trial',
+          industry: values.industry ?? null,
+          billing_email: values.billingEmail ?? null,
+          metadata: values.description ? { description: values.description } : {},
+          created_by: user.id,
+        };
+
+        const { data: insertedCompany, error: insertError } = await supabase
+          .from('companies')
+          .insert(payload)
+          .select()
+          .single();
+
+        if (insertError) {
+          throw new Error(insertError.message);
+        }
+
+        resolvedCompany = insertedCompany;
+      }
+
+      const nowIso = new Date().toISOString();
+      const membershipPayload = {
+        company_id: resolvedCompany.id,
+        user_id: user.id,
+        role: 'admin',
+        status: 'active',
+        invited_at: nowIso,
+        joined_at: nowIso,
+      };
+
+      const { error: membershipError } = await supabase
+        .from('company_members')
+        .upsert(membershipPayload, { onConflict: 'company_id,user_id' });
+
+      if (membershipError) {
+        throw new Error(membershipError.message);
+      }
+
+      const descriptionFromCompany =
+        typeof resolvedCompany.metadata?.description === 'string'
+          ? resolvedCompany.metadata.description
+          : (values.description ?? null);
+
+      const { error: updateUserError } = await supabase.auth.updateUser({
+        data: {
+          companyName: resolvedCompany.name,
+          companyDescription: descriptionFromCompany,
+          companyCode: resolvedCompany.company_code,
+        },
+      });
+
+      if (updateUserError) {
+        throw new Error(updateUserError.message);
+      }
+
+      await refreshSession();
+
+      setCompany({
+        id: resolvedCompany.id,
+        name: resolvedCompany.name,
+        companyCode: resolvedCompany.company_code,
+        countryCode: resolvedCompany.country_code,
+        defaultTimeZone: resolvedCompany.default_time_zone,
+        planTier: resolvedCompany.plan_tier,
+        description: descriptionFromCompany,
+        industry: resolvedCompany.industry,
+        billingEmail: resolvedCompany.billing_email,
+        role: 'admin',
+        status: 'active',
+      });
+
+      companyForm.reset({
+        companyCode: resolvedCompany.company_code,
+        companyName: resolvedCompany.name,
+        countryCode: resolvedCompany.country_code,
+        defaultTimeZone: resolvedCompany.default_time_zone,
+        industry: resolvedCompany.industry ?? undefined,
+        billingEmail: resolvedCompany.billing_email ?? undefined,
+        description: descriptionFromCompany ?? undefined,
+      });
+
+      Alert.alert('Empresa vinculada', 'Asociamos tu cuenta a la empresa seleccionada.');
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'No pudimos vincular tu usuario con la empresa indicada.';
+      Alert.alert('Error al vincular empresa', message);
+    } finally {
+      setIsSavingCompany(false);
+    }
+  });
+
+  if (isBootstrapping) {
+    return (
+      <View className="flex-1 items-center justify-center bg-slate-100">
+        <ActivityIndicator
+          size="large"
+          color={PRIMARY_COLOR}
+        />
+        <Text className="mt-4 text-base text-slate-500">Cargando configuración…</Text>
+      </View>
+    );
+  }
+
+  return (
+    <KeyboardAvoidingView
+      className="flex-1"
+      behavior={Platform.select({ ios: 'padding', android: undefined })}
+    >
+      <ScrollView
+        className="flex-1 bg-slate-100"
+        contentContainerStyle={{ paddingBottom: 48, paddingTop: 56 }}
+        showsVerticalScrollIndicator={false}
+      >
+        <View className="px-6">
+          <View className="mb-4 flex-row items-center justify-between">
+            <Pressable
+              accessibilityLabel="Volver"
+              accessibilityRole="button"
+              className="h-10 w-10 items-center justify-center rounded-full bg-primary-100"
+              android_ripple={{ color: 'rgba(12, 109, 217, 0.2)', borderless: false }}
+              onPress={() => {
+                if (canGoBack) {
+                  router.back();
+                } else {
+                  router.replace('/(tabs)/(home)');
+                }
+              }}
+            >
+              <MaterialIcons
+                name="arrow-back"
+                size={22}
+                color={PRIMARY_COLOR}
+              />
+            </Pressable>
+            <Text className="flex-1 text-center text-lg font-semibold text-slate-900">
+              Configuración
+            </Text>
+            <View className="h-10 w-10" />
+          </View>
+
+          <View className="rounded-3xl bg-white p-6">
+            <Text className="text-lg font-semibold text-slate-900">Datos personales</Text>
+            <Text className="mt-1 text-sm text-slate-500">
+              Completá tus datos para personalizar tu experiencia y cumplir con los requisitos del
+              área de RRHH.
+            </Text>
+
+            <View className="mt-6 gap-4">
+              <ControllerInput
+                control={profileForm.control}
+                name="fullName"
+                label="Nombre completo"
+                inputProps={{ autoCapitalize: 'words', placeholder: 'Juan Ignacio Pérez' }}
+              />
+              <ControllerInput
+                control={profileForm.control}
+                name="preferredName"
+                label="Nombre preferido"
+                inputProps={{ autoCapitalize: 'words', placeholder: 'Juan' }}
+              />
+              <ControllerInput
+                control={profileForm.control}
+                name="phone"
+                label="Teléfono"
+                keyboardType="phone-pad"
+                inputProps={{ placeholder: '+54 9 11 5555 4444' }}
+              />
+              <ControllerInput
+                control={profileForm.control}
+                name="timeZone"
+                label="Huso horario"
+                inputProps={{
+                  placeholder: 'America/Argentina/Buenos_Aires',
+                  autoCapitalize: 'none',
+                }}
+              />
+              <ControllerInput
+                control={profileForm.control}
+                name="locale"
+                label="Idioma preferido"
+                inputProps={{ placeholder: 'es-AR', autoCapitalize: 'none' }}
+              />
+              <ControllerInput
+                control={profileForm.control}
+                name="bio"
+                label="Bio"
+                inputProps={{
+                  placeholder: 'Contanos algo sobre vos',
+                  multiline: true,
+                  numberOfLines: 3,
+                }}
+              />
+              <ControllerInput
+                control={profileForm.control}
+                name="cuil"
+                label="CUIL"
+                keyboardType="number-pad"
+                inputProps={{ placeholder: '20XXXXXXXXX' }}
+              />
+            </View>
+
+            <Pressable
+              className="mt-6 items-center rounded-2xl bg-primary-600 px-6 py-3"
+              disabled={isSavingProfile}
+              onPress={() => {
+                void onSubmitProfile();
+              }}
+            >
+              {isSavingProfile ? (
+                <ActivityIndicator color="#ffffff" />
+              ) : (
+                <Text className="text-base font-semibold text-white">Guardar datos personales</Text>
+              )}
+            </Pressable>
+          </View>
+
+          <View className="mt-8 rounded-3xl bg-white p-6">
+            <Text className="text-lg font-semibold text-slate-900">Empresa</Text>
+            <Text className="mt-1 text-sm text-slate-500">
+              Ingresá el código de tu empresa para vincular tu usuario o creá la compañía si sos el
+              primer administrador.
+            </Text>
+
+            {company ? (
+              <View className="mt-6 rounded-2xl border border-primary-100 bg-primary-50 p-4">
+                <Text className="text-base font-semibold text-primary-800">{company.name}</Text>
+                <Text className="mt-1 text-sm text-primary-700">Código: {company.companyCode}</Text>
+                <Text className="text-sm text-primary-700">País: {company.countryCode}</Text>
+                <Text className="text-sm text-primary-700">
+                  Huso horario: {company.defaultTimeZone}
+                </Text>
+                {company.description ? (
+                  <Text className="mt-2 text-sm text-primary-600">{company.description}</Text>
+                ) : null}
+                <Text className="mt-3 text-xs uppercase text-primary-500">
+                  Rol: {company.role ?? 'admin'} • Estado: {company.status ?? 'active'}
+                </Text>
+              </View>
+            ) : null}
+
+            {!company ? (
+              <View className="mt-6 gap-4">
+                <ControllerInput
+                  control={companyForm.control}
+                  name="companyCode"
+                  label="Código de empresa"
+                  inputProps={{ placeholder: 'Ej: WORKFOLIO-AR', autoCapitalize: 'characters' }}
+                />
+                <ControllerInput
+                  control={companyForm.control}
+                  name="companyName"
+                  label="Nombre de la empresa"
+                  inputProps={{ placeholder: 'Workfolio', autoCapitalize: 'words' }}
+                />
+                <ControllerInput
+                  control={companyForm.control}
+                  name="countryCode"
+                  label="País (ISO 3166-1)"
+                  inputProps={{ placeholder: 'AR', autoCapitalize: 'characters' }}
+                />
+                <ControllerInput
+                  control={companyForm.control}
+                  name="defaultTimeZone"
+                  label="Huso horario por defecto"
+                  inputProps={{
+                    placeholder: 'America/Argentina/Buenos_Aires',
+                    autoCapitalize: 'none',
+                  }}
+                />
+                <ControllerInput
+                  control={companyForm.control}
+                  name="industry"
+                  label="Industria"
+                  inputProps={{ placeholder: 'Tecnología', autoCapitalize: 'words' }}
+                />
+                <ControllerInput
+                  control={companyForm.control}
+                  name="billingEmail"
+                  label="Email de contacto"
+                  keyboardType="email-address"
+                  inputProps={{ autoCapitalize: 'none', placeholder: 'finance@workfolio.com' }}
+                />
+                <ControllerInput
+                  control={companyForm.control}
+                  name="description"
+                  label="Descripción"
+                  inputProps={{
+                    placeholder: 'Descripción breve de la compañía',
+                    multiline: true,
+                    numberOfLines: 3,
+                  }}
+                />
+              </View>
+            ) : null}
+
+            {!company ? (
+              <Pressable
+                className="mt-6 items-center rounded-2xl bg-primary-600 px-6 py-3"
+                disabled={isSavingCompany}
+                onPress={() => {
+                  void onSubmitCompany();
+                }}
+              >
+                {isSavingCompany ? (
+                  <ActivityIndicator color="#ffffff" />
+                ) : (
+                  <Text className="text-base font-semibold text-white">Vincular empresa</Text>
+                )}
+              </Pressable>
+            ) : null}
+          </View>
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}

--- a/components/Skeleton.tsx
+++ b/components/Skeleton.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react';
+import { Animated, StyleProp, ViewStyle } from 'react-native';
+
+type SkeletonProps = {
+  className?: string;
+  style?: StyleProp<ViewStyle>;
+};
+
+export function Skeleton({ className, style }: SkeletonProps) {
+  const opacity = useRef(new Animated.Value(0.6)).current;
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, {
+          toValue: 0.35,
+          duration: 700,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 0.75,
+          duration: 700,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+
+    animation.start();
+
+    return () => {
+      animation.stop();
+    };
+  }, [opacity]);
+
+  const classes = className ? `${className} bg-slate-200` : 'bg-slate-200';
+
+  return (
+    <Animated.View
+      className={classes}
+      style={[style, { opacity }]}
+    />
+  );
+}

--- a/components/custom/GradientBackground/GradientBackground.tsx
+++ b/components/custom/GradientBackground/GradientBackground.tsx
@@ -16,10 +16,7 @@ type GradientBackgroundProps = {
 export function GradientBackground({ children, className }: GradientBackgroundProps) {
   return (
     <View className={cn('flex-1 overflow-hidden', className)}>
-      <Svg
-        pointerEvents="none"
-        style={StyleSheet.absoluteFill}
-      >
+      <Svg style={[StyleSheet.absoluteFill, { pointerEvents: 'none' }]}>
         <Defs>
           <SvgLinearGradient
             id="softGradient"

--- a/components/custom/NavMenu/NavMenu.tsx
+++ b/components/custom/NavMenu/NavMenu.tsx
@@ -72,13 +72,14 @@ export function NavMenu({ visible, onClose, onNavigate, onLogout, user }: NavMen
     { key: 'home', label: 'Home', path: '/(tabs)/(home)', icon: 'home' },
     { key: 'paychecks', label: 'Recibos', path: '/(tabs)/(paychecks)', icon: 'credit-card' },
     { key: 'documents', label: 'Documents', path: '/(tabs)/(documents)', icon: 'file-text' },
+    { key: 'settings', label: 'Configuración', path: '/settings', icon: 'settings' },
     { key: 'change-pin', label: 'Change PIN', path: '/change-pin', icon: 'lock' },
   ];
 
   return (
     <View
-      pointerEvents={visible ? 'auto' : 'none'}
       className="absolute inset-0 z-50"
+      style={{ pointerEvents: visible ? 'auto' : 'none' }}
     >
       <Animated.View
         className="absolute inset-0 bg-slate-950/70"
@@ -91,10 +92,11 @@ export function NavMenu({ visible, onClose, onNavigate, onLogout, user }: NavMen
       </Animated.View>
 
       <Animated.View
-        className="absolute top-0 bottom-0 right-0 shadow-2xl shadow-slate-900/40"
+        className="absolute top-0 bottom-0 right-0"
         style={{
           width: MENU_WIDTH,
           transform: [{ translateX }],
+          boxShadow: '0px 24px 48px rgba(15, 23, 42, 0.35)',
         }}
       >
         <View

--- a/components/custom/PermissionModal/PermissionModal.tsx
+++ b/components/custom/PermissionModal/PermissionModal.tsx
@@ -26,7 +26,7 @@ export function PermissionModal({
       visible={visible}
     >
       <View className="flex-1 items-center justify-center bg-slate-900/60 px-6">
-        <View className="w-full rounded-3xl bg-white p-6 shadow-xl">
+        <View className="w-full rounded-3xl bg-white p-6">
           <Text className="text-lg font-semibold text-slate-900">{title}</Text>
           <Text className="mt-2 text-sm text-slate-500">{description}</Text>
 

--- a/components/layout/documents/DocumentsHeader.tsx
+++ b/components/layout/documents/DocumentsHeader.tsx
@@ -2,7 +2,6 @@ import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import type { NativeStackHeaderProps } from '@react-navigation/native-stack';
 import { useMemo } from 'react';
 import { Pressable, Text, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import type { DocumentsHeaderProps } from './types';
 
@@ -12,7 +11,6 @@ export function DocumentsHeader({
   options,
   route,
 }: NativeStackHeaderProps & DocumentsHeaderProps) {
-  const insets = useSafeAreaInsets();
   const title = useMemo(() => {
     if (typeof options.headerTitle === 'string') {
       return options.headerTitle;
@@ -28,7 +26,7 @@ export function DocumentsHeader({
 
   return (
     <View className="bg-primary-600">
-      <View className=" bg-primary-600 px-6 pb-4 pt-4 shadow-sm">
+      <View className=" bg-primary-600 px-6 pb-4 pt-4">
         <View className="flex-row items-center justify-between">
           {back ? (
             <Pressable

--- a/hooks/useAuth.tsx
+++ b/hooks/useAuth.tsx
@@ -183,7 +183,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
         }
 
         async function runWithForeignKeyRetry<T>(
-          operation: () => Promise<{ data: T | null; error: { code?: string; message: string } | null }>,
+          operation: () => Promise<{
+            data: T | null;
+            error: { code?: string; message: string } | null;
+          }>,
           fallbackMessage: string,
         ): Promise<T | null> {
           let lastError: { code?: string; message: string } | null = null;
@@ -319,13 +322,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
         const nowIso = new Date().toISOString();
 
-        const targetTimeZone =
-          defaultTimeZone ?? targetCompany.default_time_zone ?? 'UTC';
+        const targetTimeZone = defaultTimeZone ?? targetCompany.default_time_zone ?? 'UTC';
 
         const profilePayload = {
           user_id: userId,
           full_name:
-            normalizedFullName.length > 0 ? normalizedFullName : email.split('@')[0] ?? email,
+            normalizedFullName.length > 0 ? normalizedFullName : (email.split('@')[0] ?? email),
           preferred_name: firstName ?? null,
           time_zone: targetTimeZone,
           locale: 'es',
@@ -358,12 +360,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
             supabase
               .from('company_members')
               .upsert(membershipPayload, { onConflict: 'company_id,user_id' })
-              .select('id, company_id, role')
+              .select('id, company_id, role, status')
               .single(),
           'No pudimos crear tu membresía en la empresa.',
         );
 
-        if (membershipRow && membershipRow.role === 'admin') {
+        if (membershipRow?.id) {
           await runWithForeignKeyRetry(
             () =>
               supabase
@@ -372,7 +374,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
                   {
                     company_id: membershipRow.company_id,
                     member_id: membershipRow.id,
-                    is_active: true,
+                    is_active: membershipRow.status === 'active',
                   },
                   { onConflict: 'member_id' },
                 )

--- a/hooks/useEmployeeContext.ts
+++ b/hooks/useEmployeeContext.ts
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  getActiveMembershipForUser,
+  getEmployeeProfileByMemberId,
+  ensureEmployeeProfileForMember,
+} from '@/lib/repositories';
+import type { CompanyMember, EmployeeProfile } from '@/types/db';
+
+import { useAuth } from './useAuth';
+
+export type EmployeeContextValue = {
+  companyId: string | null;
+  membershipId: string | null;
+  membership: CompanyMember | null;
+  employeeId: string | null;
+  employeeProfile: EmployeeProfile | null;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+};
+
+const initialState = {
+  membership: null as CompanyMember | null,
+  employeeProfile: null as EmployeeProfile | null,
+  error: null as string | null,
+  isLoading: false,
+};
+
+export function useEmployeeContext(): EmployeeContextValue {
+  const { user, isAuthLoading } = useAuth();
+  const [state, setState] = useState(initialState);
+
+  const refresh = useCallback(async () => {
+    if (!user?.id) {
+      setState({
+        membership: null,
+        employeeProfile: null,
+        error: null,
+        isLoading: false,
+      });
+      return;
+    }
+
+    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+
+    try {
+      const membership = await getActiveMembershipForUser(user.id);
+
+      if (!membership) {
+        setState({
+          membership: null,
+          employeeProfile: null,
+          error: 'No encontramos una compañía asociada a tu usuario.',
+          isLoading: false,
+        });
+        return;
+      }
+
+      let employeeProfile: EmployeeProfile | null = null;
+
+      if (membership.role === 'employee') {
+        employeeProfile = await getEmployeeProfileByMemberId(membership.id);
+      } else if (membership.role === 'admin') {
+        employeeProfile = await ensureEmployeeProfileForMember(membership.company_id, membership.id);
+      }
+      setState({
+        membership,
+        employeeProfile: employeeProfile ?? null,
+        error: null,
+        isLoading: false,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'No pudimos cargar tus datos.';
+      setState({
+        membership: null,
+        employeeProfile: null,
+        error: message,
+        isLoading: false,
+      });
+    }
+  }, [user?.id]);
+
+  useEffect(() => {
+    if (isAuthLoading) {
+      return;
+    }
+
+    void refresh();
+  }, [isAuthLoading, refresh]);
+  const value = useMemo(() => {
+    const companyId = state.membership?.company_id ?? null;
+    const membershipId = state.membership?.id ?? null;
+    const employeeId = state.employeeProfile?.id ?? null;
+
+    return {
+      companyId,
+      membershipId,
+      membership: state.membership ?? null,
+      employeeId,
+      employeeProfile: state.employeeProfile ?? null,
+      isLoading: isAuthLoading || state.isLoading,
+      error: state.error,
+      refresh,
+    };
+  }, [state, refresh, isAuthLoading]);
+
+  return value;
+}

--- a/hooks/useEmployeeDocuments.ts
+++ b/hooks/useEmployeeDocuments.ts
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  createDocumentFileSignedUrl,
+  getDocumentFilesByDocumentIds,
+  getDocumentsForEmployee,
+} from '@/lib/repositories';
+import type { Document, DocumentFile } from '@/types/db';
+import type { DocumentGroup, DocumentRecord, DocumentTypeKey } from '@/types/screens/documents';
+import {
+  createEmptyDocumentGroups,
+  DOCUMENT_TYPE_LABELS,
+  normalizeDocumentTypeKey,
+} from '@/types/screens/documents';
+
+import { useEmployeeContext } from './useEmployeeContext';
+
+const mapFilesByDocument = (files: DocumentFile[]): Map<string, DocumentFile> => {
+  const latest = new Map<string, DocumentFile>();
+
+  for (const file of files) {
+    const documentId = file.document_id;
+    if (!documentId) {
+      continue;
+    }
+
+    const existing = latest.get(documentId);
+    if (!existing) {
+      latest.set(documentId, file);
+      continue;
+    }
+
+    if (file.version > existing.version) {
+      latest.set(documentId, file);
+      continue;
+    }
+
+    if (file.version === existing.version) {
+      const existingDate = existing.uploaded_at ? new Date(existing.uploaded_at).getTime() : 0;
+      const candidateDate = file.uploaded_at ? new Date(file.uploaded_at).getTime() : 0;
+      if (candidateDate > existingDate) {
+        latest.set(documentId, file);
+      }
+    }
+  }
+
+  return latest;
+};
+
+const buildDocumentRecord = (
+  document: Document,
+  file: DocumentFile | undefined,
+): DocumentRecord => {
+  const metadata = (document.metadata ?? {}) as Record<string, unknown>;
+  const categoryRaw = (metadata.categoryKey ?? metadata.category_key) as string | undefined;
+  const categoryKey = normalizeDocumentTypeKey(categoryRaw);
+  const categoryLabel = DOCUMENT_TYPE_LABELS[categoryKey];
+  const notes = typeof metadata.notes === 'string' ? metadata.notes : null;
+
+  return {
+    id: document.id,
+    title: document.title,
+    status: document.status,
+    categoryKey,
+    categoryLabel,
+    notes,
+    fileId: file?.id ?? null,
+    filePath: file?.file_path ?? null,
+    fileVersion: file?.version ?? null,
+    contentType: file?.content_type ?? null,
+    uploadedAt: file?.uploaded_at ?? null,
+  };
+};
+
+const groupDocuments = (records: DocumentRecord[]): DocumentGroup[] => {
+  const baseMap = new Map<DocumentTypeKey, DocumentGroup>(
+    createEmptyDocumentGroups().map((group) => [group.key, { ...group }]),
+  );
+
+  for (const record of records) {
+    const group = baseMap.get(record.categoryKey);
+    if (group) {
+      group.documents.push(record);
+    } else {
+      const fallback = baseMap.get('otros');
+      fallback?.documents.push(record);
+    }
+  }
+
+  return Array.from(baseMap.values());
+};
+
+export type EmployeeDocumentsValue = {
+  companyId: string | null;
+  employeeId: string | null;
+  documents: DocumentRecord[];
+  groups: DocumentGroup[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  downloadDocument: (record: DocumentRecord) => Promise<string>;
+};
+
+export function useEmployeeDocuments(): EmployeeDocumentsValue {
+  const { companyId, employeeId, isLoading: isContextLoading, error: contextError } =
+    useEmployeeContext();
+  const [documents, setDocuments] = useState<DocumentRecord[]>([]);
+  const [groups, setGroups] = useState<DocumentGroup[]>(createEmptyDocumentGroups);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!companyId || !employeeId) {
+      setDocuments([]);
+      setGroups(createEmptyDocumentGroups());
+      setError(contextError ?? null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const docs = await getDocumentsForEmployee(companyId, employeeId);
+      const documentIds = docs.map((doc) => doc.id);
+
+      const files =
+        documentIds.length > 0
+          ? await getDocumentFilesByDocumentIds(companyId, documentIds)
+          : ([] as DocumentFile[]);
+
+      const fileMap = mapFilesByDocument(files);
+      const records = docs.map((doc) => buildDocumentRecord(doc, fileMap.get(doc.id)));
+      records.sort((a, b) => {
+        const aDate = a.uploadedAt ?? null;
+        const bDate = b.uploadedAt ?? null;
+        if (!aDate && !bDate) {
+          return 0;
+        }
+        if (!aDate) {
+          return 1;
+        }
+        if (!bDate) {
+          return -1;
+        }
+        return new Date(bDate).getTime() - new Date(aDate).getTime();
+      });
+
+      setDocuments(records);
+      setGroups(groupDocuments(records));
+    } catch (unknownError) {
+      const message =
+        unknownError instanceof Error ? unknownError.message : 'No pudimos cargar tus documentos.';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [companyId, employeeId, contextError]);
+
+  useEffect(() => {
+    if (isContextLoading) {
+      return;
+    }
+
+    void refresh();
+  }, [refresh, isContextLoading]);
+
+  const downloadDocument = useCallback(
+    async (record: DocumentRecord) => {
+      if (!record.filePath) {
+        throw new Error('El documento no tiene un archivo asociado.');
+      }
+
+      const result = await createDocumentFileSignedUrl(record.filePath, {
+        expiresIn: 60,
+        download: true,
+        fileName: record.title,
+      });
+
+      return result.signedUrl;
+    },
+    [],
+  );
+
+  return {
+    companyId,
+    employeeId,
+    documents,
+    groups,
+    isLoading: isLoading || isContextLoading,
+    error: error ?? contextError ?? null,
+    refresh,
+    downloadDocument,
+  };
+}

--- a/hooks/useEmployeeDocuments.ts
+++ b/hooks/useEmployeeDocuments.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import {
   createDocumentFileSignedUrl,
@@ -95,6 +95,7 @@ export type EmployeeDocumentsValue = {
   employeeId: string | null;
   documents: DocumentRecord[];
   groups: DocumentGroup[];
+  hasLoaded: boolean;
   isLoading: boolean;
   error: string | null;
   refresh: () => Promise<void>;
@@ -102,18 +103,24 @@ export type EmployeeDocumentsValue = {
 };
 
 export function useEmployeeDocuments(): EmployeeDocumentsValue {
-  const { companyId, employeeId, isLoading: isContextLoading, error: contextError } =
-    useEmployeeContext();
+  const {
+    companyId,
+    employeeId,
+    isLoading: isContextLoading,
+    error: contextError,
+  } = useEmployeeContext();
   const [documents, setDocuments] = useState<DocumentRecord[]>([]);
   const [groups, setGroups] = useState<DocumentGroup[]>(createEmptyDocumentGroups);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [hasLoaded, setHasLoaded] = useState(false);
 
   const refresh = useCallback(async () => {
     if (!companyId || !employeeId) {
       setDocuments([]);
       setGroups(createEmptyDocumentGroups());
       setError(contextError ?? null);
+      setHasLoaded(false);
       return;
     }
 
@@ -154,39 +161,39 @@ export function useEmployeeDocuments(): EmployeeDocumentsValue {
       setError(message);
     } finally {
       setIsLoading(false);
+      setHasLoaded(true);
     }
   }, [companyId, employeeId, contextError]);
 
   useEffect(() => {
     if (isContextLoading) {
+      setHasLoaded(false);
       return;
     }
 
     void refresh();
   }, [refresh, isContextLoading]);
 
-  const downloadDocument = useCallback(
-    async (record: DocumentRecord) => {
-      if (!record.filePath) {
-        throw new Error('El documento no tiene un archivo asociado.');
-      }
+  const downloadDocument = useCallback(async (record: DocumentRecord) => {
+    if (!record.filePath) {
+      throw new Error('El documento no tiene un archivo asociado.');
+    }
 
-      const result = await createDocumentFileSignedUrl(record.filePath, {
-        expiresIn: 60,
-        download: true,
-        fileName: record.title,
-      });
+    const result = await createDocumentFileSignedUrl(record.filePath, {
+      expiresIn: 60,
+      download: true,
+      fileName: record.title,
+    });
 
-      return result.signedUrl;
-    },
-    [],
-  );
+    return result.signedUrl;
+  }, []);
 
   return {
     companyId,
     employeeId,
     documents,
     groups,
+    hasLoaded,
     isLoading: isLoading || isContextLoading,
     error: error ?? contextError ?? null,
     refresh,

--- a/hooks/useEmployeePaychecks.ts
+++ b/hooks/useEmployeePaychecks.ts
@@ -1,0 +1,169 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { createPaycheckSignedUrl, getPaychecksForEmployee } from '@/lib/repositories';
+import type { Paycheck } from '@/types/db';
+import type { PaycheckEntry, PaycheckGroup } from '@/types/screens/paychecks';
+
+import { useEmployeeContext } from './useEmployeeContext';
+
+const formatMonthLabel = (isoDate: string): string => {
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) {
+    return 'Recibo';
+  }
+
+  const formatter = new Intl.DateTimeFormat('es-AR', {
+    month: 'short',
+    year: 'numeric',
+  });
+
+  return formatter.format(date);
+};
+
+const formatPeriodDescription = (paycheck: Paycheck, fallback: string): string => {
+  const metadata = (paycheck.metadata ?? {}) as Record<string, unknown>;
+  const description = metadata.description;
+
+  if (typeof description === 'string' && description.trim().length > 0) {
+    return description.trim();
+  }
+
+  const { period_start: start, period_end: end } = paycheck;
+  if (start && end) {
+    const startDate = new Date(start);
+    const endDate = new Date(end);
+    if (!Number.isNaN(startDate.getTime()) && !Number.isNaN(endDate.getTime())) {
+      const formatter = new Intl.DateTimeFormat('es-AR', {
+        day: '2-digit',
+        month: 'short',
+      });
+      return `Período ${formatter.format(startDate)} – ${formatter.format(endDate)}`;
+    }
+  }
+
+  return fallback;
+};
+
+const buildPaycheckEntry = (paycheck: Paycheck): PaycheckEntry => {
+  const issuedLabel = paycheck.issued_at ? formatMonthLabel(paycheck.issued_at) : 'Recibo';
+  const description = formatPeriodDescription(paycheck, 'Recibo salarial');
+
+  return {
+    id: paycheck.id,
+    issuedAt: paycheck.issued_at,
+    label: issuedLabel,
+    description,
+    status: paycheck.status,
+    grossAmount: paycheck.gross_amount,
+    netAmount: paycheck.net_amount,
+    currency: paycheck.currency,
+    filePath: paycheck.file_path,
+  };
+};
+
+const groupPaychecks = (entries: PaycheckEntry[]): PaycheckGroup[] => {
+  const groupsMap = new Map<number, PaycheckGroup>();
+
+  for (const entry of entries) {
+    const year = entry.issuedAt ? new Date(entry.issuedAt).getFullYear() : new Date().getFullYear();
+    if (!groupsMap.has(year)) {
+      groupsMap.set(year, { year, items: [] });
+    }
+    groupsMap.get(year)?.items.push(entry);
+  }
+
+  const groups = Array.from(groupsMap.values());
+  groups.sort((a, b) => b.year - a.year);
+  groups.forEach((group) => {
+    group.items.sort((a, b) => new Date(b.issuedAt).getTime() - new Date(a.issuedAt).getTime());
+  });
+  return groups;
+};
+
+export type EmployeePaychecksValue = {
+  companyId: string | null;
+  employeeId: string | null;
+  paychecks: PaycheckEntry[];
+  groups: PaycheckGroup[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  downloadPaycheck: (entry: PaycheckEntry) => Promise<string>;
+};
+
+export function useEmployeePaychecks(): EmployeePaychecksValue {
+  const { companyId, employeeId, isLoading: isContextLoading, error: contextError } =
+    useEmployeeContext();
+  const [paychecks, setPaychecks] = useState<PaycheckEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!companyId || !employeeId) {
+      setPaychecks([]);
+      setError(contextError ?? null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const rows = await getPaychecksForEmployee(companyId, employeeId);
+      const entries = rows
+        .map((row) => buildPaycheckEntry(row))
+        .sort((a, b) => new Date(b.issuedAt).getTime() - new Date(a.issuedAt).getTime());
+      setPaychecks(entries);
+    } catch (unknownError) {
+      const message =
+        unknownError instanceof Error
+          ? unknownError.message
+          : 'No pudimos cargar tus recibos de sueldo.';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [companyId, employeeId, contextError]);
+
+  useEffect(() => {
+    if (isContextLoading) {
+      return;
+    }
+
+    void refresh();
+  }, [refresh, isContextLoading]);
+
+  const downloadPaycheck = useCallback(
+    async (entry: PaycheckEntry) => {
+      if (!companyId) {
+        throw new Error('No pudimos determinar tu compañía para descargar el recibo.');
+      }
+
+      if (!entry.filePath) {
+        throw new Error('El recibo no tiene un archivo disponible.');
+      }
+
+      const result = await createPaycheckSignedUrl(companyId, entry.id, {
+        expiresIn: 120,
+        download: true,
+        fileName: `${entry.label}.pdf`,
+      });
+
+      return result.signedUrl;
+    },
+    [companyId],
+  );
+
+  const groups = useMemo(() => groupPaychecks(paychecks), [paychecks]);
+
+  return {
+    companyId,
+    employeeId,
+    paychecks,
+    groups,
+    isLoading: isLoading || isContextLoading,
+    error: error ?? contextError ?? null,
+    refresh,
+    downloadPaycheck,
+  };
+}

--- a/hooks/useEmployeePaychecks.ts
+++ b/hooks/useEmployeePaychecks.ts
@@ -92,8 +92,12 @@ export type EmployeePaychecksValue = {
 };
 
 export function useEmployeePaychecks(): EmployeePaychecksValue {
-  const { companyId, employeeId, isLoading: isContextLoading, error: contextError } =
-    useEmployeeContext();
+  const {
+    companyId,
+    employeeId,
+    isLoading: isContextLoading,
+    error: contextError,
+  } = useEmployeeContext();
   const [paychecks, setPaychecks] = useState<PaycheckEntry[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/lib/adapters/supabaseAdapter.ts
+++ b/lib/adapters/supabaseAdapter.ts
@@ -1,0 +1,103 @@
+import type {
+  PostgrestError,
+  PostgrestMaybeSingleResponse,
+  PostgrestResponse,
+  PostgrestSingleResponse,
+} from '@supabase/supabase-js';
+
+export class RepositoryError extends Error {
+  public readonly original?: PostgrestError;
+
+  public readonly status?: number;
+
+  public readonly code?: string;
+
+  public readonly details?: string;
+
+  public readonly hint?: string;
+
+  constructor(message: string, options: { cause?: PostgrestError; status?: number } = {}) {
+    super(message);
+    this.name = 'RepositoryError';
+    this.original = options.cause;
+    this.status = options.status;
+
+    if (options.cause) {
+      this.code = options.cause.code;
+      this.details = options.cause.details;
+      this.hint = options.cause.hint;
+    }
+  }
+}
+
+const formatMessage = (fallback: string, error?: PostgrestError) => {
+  if (!error) {
+    return fallback;
+  }
+
+  return `${fallback}: ${error.message}`;
+};
+
+export const unwrapSingle = <T>(
+  response: PostgrestSingleResponse<T>,
+  notFoundMessage = 'Record not found',
+  failureMessage = 'Failed to fetch record',
+): T => {
+  if (response.error) {
+    throw new RepositoryError(formatMessage(failureMessage, response.error), {
+      cause: response.error,
+      status: response.status,
+    });
+  }
+
+  if (!response.data) {
+    throw new RepositoryError(notFoundMessage, { status: 404 });
+  }
+
+  return response.data;
+};
+
+export const unwrapMaybeSingle = <T>(
+  response: PostgrestMaybeSingleResponse<T>,
+  failureMessage = 'Failed to fetch record',
+): T | null => {
+  if (response.error) {
+    throw new RepositoryError(formatMessage(failureMessage, response.error), {
+      cause: response.error,
+      status: response.status,
+    });
+  }
+
+  return response.data ?? null;
+};
+
+export const unwrapList = <T>(
+  response: PostgrestResponse<T>,
+  failureMessage = 'Failed to fetch records',
+): T[] => {
+  if (response.error) {
+    throw new RepositoryError(formatMessage(failureMessage, response.error), {
+      cause: response.error,
+      status: response.status,
+    });
+  }
+
+  return response.data ?? [];
+};
+
+export const ensureMutation = <T>(
+  response: PostgrestSingleResponse<T>,
+  failureMessage = 'Failed to persist record',
+): T => unwrapSingle(response, 'Record not found', failureMessage);
+
+export const ensureNoError = (
+  response: PostgrestResponse<unknown>,
+  failureMessage = 'Failed to execute operation',
+): void => {
+  if (response.error) {
+    throw new RepositoryError(formatMessage(failureMessage, response.error), {
+      cause: response.error,
+      status: response.status,
+    });
+  }
+};

--- a/lib/adapters/supabaseStorage.ts
+++ b/lib/adapters/supabaseStorage.ts
@@ -1,0 +1,141 @@
+import type { StorageError } from '@supabase/storage-js';
+
+import { supabase } from '@/lib/supabase';
+import { RepositoryError } from '@/lib/adapters/supabaseAdapter';
+import type {
+  SignedUrlOptions,
+  SignedUrlResult,
+  StorageBucket,
+  StorageFile,
+  StorageRemoveResult,
+  StorageUploadOptions,
+  StorageUploadResult,
+} from '@/types/storage';
+
+const formatMessage = (fallback: string, error?: StorageError | Error) => {
+  if (!error) {
+    return fallback;
+  }
+
+  const message = 'message' in error ? error.message : fallback;
+  return `${fallback}: ${message}`;
+};
+
+const ensureBucket = (bucket: StorageBucket): StorageBucket => bucket;
+
+export const uploadFile = async (
+  bucket: StorageBucket,
+  path: string,
+  file: StorageFile,
+  options: StorageUploadOptions = {},
+): Promise<StorageUploadResult> => {
+  const client = supabase.storage.from(ensureBucket(bucket));
+  const { data, error } = await client.upload(path, file, options);
+
+  if (error || !data?.path) {
+    throw new RepositoryError(formatMessage('Failed to upload file', error ?? undefined), {
+      cause: error ?? undefined,
+      status: error?.status,
+    });
+  }
+
+  return {
+    bucket,
+    path: data.path,
+    fullPath: `${bucket}/${data.path}`,
+  };
+};
+
+export const createSignedUrl = async (
+  bucket: StorageBucket,
+  path: string,
+  options: SignedUrlOptions,
+): Promise<SignedUrlResult> => {
+  const client = supabase.storage.from(ensureBucket(bucket));
+  const { data, error } = await client.createSignedUrl(path, options.expiresIn, {
+    download: options.download,
+    fileName: options.fileName,
+    transform: options.transform,
+  });
+
+  if (error || !data?.signedUrl) {
+    throw new RepositoryError(formatMessage('Failed to create signed URL', error ?? undefined), {
+      cause: error ?? undefined,
+      status: error?.status,
+    });
+  }
+
+  return {
+    bucket,
+    path,
+    signedUrl: data.signedUrl,
+    expiresAt: data.expiry ?? Date.now() + options.expiresIn * 1000,
+  };
+};
+
+export const getPublicUrl = (bucket: StorageBucket, path: string): string => {
+  const client = supabase.storage.from(ensureBucket(bucket));
+  const { data } = client.getPublicUrl(path);
+
+  return data.publicUrl;
+};
+
+export const removeFiles = async (
+  bucket: StorageBucket,
+  paths: string[],
+): Promise<StorageRemoveResult[]> => {
+  if (!paths.length) {
+    return [];
+  }
+
+  const client = supabase.storage.from(ensureBucket(bucket));
+  const { data, error } = await client.remove(paths);
+
+  if (error) {
+    throw new RepositoryError(formatMessage('Failed to remove files', error), {
+      cause: error,
+      status: error.status,
+    });
+  }
+
+  return (data ?? []).map((path) => ({ bucket, path }));
+};
+
+export const moveFile = async (
+  bucket: StorageBucket,
+  from: string,
+  to: string,
+): Promise<StorageUploadResult> => {
+  const client = supabase.storage.from(ensureBucket(bucket));
+  const { data, error } = await client.move(from, to);
+
+  if (error || !data?.path) {
+    throw new RepositoryError(formatMessage('Failed to move file', error ?? undefined), {
+      cause: error ?? undefined,
+      status: error?.status,
+    });
+  }
+
+  return {
+    bucket,
+    path: data.path,
+    fullPath: `${bucket}/${data.path}`,
+  };
+};
+
+export const downloadFile = async (
+  bucket: StorageBucket,
+  path: string,
+): Promise<Blob | ArrayBuffer> => {
+  const client = supabase.storage.from(ensureBucket(bucket));
+  const { data, error } = await client.download(path);
+
+  if (error || !data) {
+    throw new RepositoryError(formatMessage('Failed to download file', error ?? undefined), {
+      cause: error ?? undefined,
+      status: error?.status,
+    });
+  }
+
+  return data;
+};

--- a/lib/middlewares/ensureCompanyScope.ts
+++ b/lib/middlewares/ensureCompanyScope.ts
@@ -1,0 +1,21 @@
+import { RepositoryError } from '@/lib/adapters/supabaseAdapter';
+
+export const ensureCompanyScope = (companyId: string | null | undefined): string => {
+  if (!companyId) {
+    throw new RepositoryError('A company identifier is required for this operation.', {
+      status: 400,
+    });
+  }
+
+  return companyId;
+};
+
+export const ensureIdentifier = (value: string | null | undefined, label = 'id'): string => {
+  if (!value) {
+    throw new RepositoryError(`A valid ${label} must be provided.`, {
+      status: 400,
+    });
+  }
+
+  return value;
+};

--- a/lib/repositories/README.md
+++ b/lib/repositories/README.md
@@ -1,0 +1,9 @@
+# Repository Layer
+
+This folder centralizes data-access helpers that wrap Supabase PostgREST queries and Storage operations. Modules are grouped by domain (`company`, `user`, `documents`, `events`, `notifications`, `paychecks`) with storage-specific helpers co-located for upload/download flows.
+
+- `companyRepository`, `userRepository`, `documentsRepository`, `eventsRepository`, `notificationsRepository`, `paychecksRepository` expose CRUD functions that return typed entities from `types/db`.
+- `documentStorageRepository`, `paychecksStorageRepository`, `avatarStorageRepository` provide canonical path builders plus helper functions for uploads, signed URLs, and cleanup across Storage buckets (`documents`, `paychecks`, `avatars`).
+- Shared adapters (`supabaseAdapter`, `supabaseStorage`) normalize Supabase responses and surface errors through `RepositoryError` so consumers can handle failures consistently.
+
+When wiring screens or hooks, prefer these helpers over inline Supabase calls to keep tenant-scoping (`ensureCompanyScope`) and error handling consistent.

--- a/lib/repositories/avatarStorageRepository.ts
+++ b/lib/repositories/avatarStorageRepository.ts
@@ -1,0 +1,109 @@
+import { uploadFile, createSignedUrl, removeFiles, getPublicUrl } from '@/lib/adapters/supabaseStorage';
+import { RepositoryError } from '@/lib/adapters/supabaseAdapter';
+import { ensureIdentifier } from '@/lib/middlewares/ensureCompanyScope';
+import {
+  getUserProfileById,
+  updateUserProfile,
+} from '@/lib/repositories/userRepository';
+import type { UserProfile } from '@/types/db';
+import type { SignedUrlOptions, SignedUrlResult, StorageFile, StorageUploadOptions } from '@/types/storage';
+
+const sanitizeFileName = (fileName: string): string => fileName.trim().replace(/\s+/g, '-');
+
+const buildAvatarPath = ({
+  userId,
+  fileName,
+}: {
+  userId: string;
+  fileName: string;
+}): string => `users/${userId}/${Date.now()}-${sanitizeFileName(fileName)}`;
+
+const extractStoredPath = (avatarUrl: string | null): string | null => {
+  if (!avatarUrl) {
+    return null;
+  }
+
+  if (avatarUrl.startsWith('http://') || avatarUrl.startsWith('https://')) {
+    return null;
+  }
+
+  return avatarUrl;
+};
+
+export interface UploadAvatarParams {
+  userId: string;
+  file: StorageFile;
+  fileName: string;
+  contentType?: string;
+  storageOptions?: StorageUploadOptions;
+  usePublicUrl?: boolean;
+  removePrevious?: boolean;
+}
+
+export interface UploadAvatarResult {
+  profile: UserProfile;
+  path: string;
+  publicUrl?: string;
+}
+
+export const uploadAvatar = async (
+  params: UploadAvatarParams,
+): Promise<UploadAvatarResult> => {
+  const userId = ensureIdentifier(params.userId, 'userId');
+  const profile = await getUserProfileById(userId);
+  const path = buildAvatarPath({ userId, fileName: params.fileName });
+
+  await uploadFile('avatars', path, params.file, {
+    cacheControl: params.storageOptions?.cacheControl,
+    contentType: params.contentType,
+    metadata: params.storageOptions?.metadata,
+    upsert: params.storageOptions?.upsert ?? true,
+  });
+
+  const previousPath = extractStoredPath(profile.avatar_url);
+  if (params.removePrevious !== false && previousPath && previousPath !== path) {
+    await removeFiles('avatars', [previousPath]);
+  }
+
+  const updatedProfile = await updateUserProfile(userId, {
+    avatar_url: params.usePublicUrl ? getPublicUrl('avatars', path) : path,
+  });
+
+  const result: UploadAvatarResult = {
+    profile: updatedProfile,
+    path,
+  };
+
+  if (params.usePublicUrl) {
+    result.publicUrl = updatedProfile.avatar_url ?? undefined;
+  }
+
+  return result;
+};
+
+export const createAvatarSignedUrl = async (
+  userId: string,
+  options: SignedUrlOptions,
+): Promise<SignedUrlResult> => {
+  const profile = await getUserProfileById(ensureIdentifier(userId, 'userId'));
+  const storedPath = extractStoredPath(profile.avatar_url);
+
+  if (!storedPath) {
+    throw new RepositoryError('Avatar not found or stored as external URL', { status: 404 });
+  }
+
+  return createSignedUrl('avatars', storedPath, options);
+};
+
+export const deleteAvatar = async (userId: string): Promise<UserProfile> => {
+  const profile = await getUserProfileById(ensureIdentifier(userId, 'userId'));
+  const storedPath = extractStoredPath(profile.avatar_url);
+
+  if (storedPath) {
+    await removeFiles('avatars', [storedPath]);
+  }
+
+  return updateUserProfile(profile.user_id, {
+    avatar_url: null,
+  });
+};

--- a/lib/repositories/companyRepository.ts
+++ b/lib/repositories/companyRepository.ts
@@ -1,0 +1,272 @@
+import { supabase } from '@/lib/supabase';
+import {
+  ensureMutation,
+  ensureNoError,
+  RepositoryError,
+  unwrapList,
+  unwrapMaybeSingle,
+} from '@/lib/adapters/supabaseAdapter';
+import { ensureCompanyScope, ensureIdentifier } from '@/lib/middlewares/ensureCompanyScope';
+import type {
+  AuditLog,
+  AuditLogInsert,
+  AuditLogReplace,
+  AuditLogUpdate,
+  Company,
+  CompanyInsert,
+  CompanyMember,
+  CompanyMemberInsert,
+  CompanyMemberReplace,
+  CompanyMemberUpdate,
+  CompanyReplace,
+  CompanyUpdate,
+} from '@/types/db';
+
+export const getAllCompanies = async (): Promise<Company[]> => {
+  const response = await supabase
+    .from<Company>('companies')
+    .select('*')
+    .order('created_at', { ascending: true });
+
+  return unwrapList(response, 'Unable to load companies');
+};
+
+export const getCompanyById = async (id: string): Promise<Company> => {
+  const response = await supabase
+    .from<Company>('companies')
+    .select('*')
+    .eq('id', ensureIdentifier(id, 'companyId'))
+    .maybeSingle();
+
+  const company = unwrapMaybeSingle(response, 'Unable to load company');
+
+  if (!company) {
+    throw new RepositoryError('Company not found', { status: 404 });
+  }
+
+  return company;
+};
+
+export const createCompany = async (payload: CompanyInsert): Promise<Company> => {
+  const response = await supabase
+    .from<Company>('companies')
+    .insert(payload)
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to create company');
+};
+
+export const replaceCompany = async (
+  id: string,
+  payload: CompanyReplace,
+): Promise<Company> => {
+  const response = await supabase
+    .from<Company>('companies')
+    .update(payload)
+    .eq('id', ensureIdentifier(id, 'companyId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to replace company');
+};
+
+export const updateCompany = async (
+  id: string,
+  payload: CompanyUpdate,
+): Promise<Company> => {
+  const response = await supabase
+    .from<Company>('companies')
+    .update(payload)
+    .eq('id', ensureIdentifier(id, 'companyId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to update company');
+};
+
+export const deleteCompany = async (id: string): Promise<void> => {
+  const response = await supabase
+    .from('companies')
+    .delete()
+    .eq('id', ensureIdentifier(id, 'companyId'));
+
+  ensureNoError(response, 'Unable to delete company');
+};
+
+export const getCompanyMembers = async (
+  companyId: string,
+): Promise<CompanyMember[]> => {
+  const response = await supabase
+    .from<CompanyMember>('company_members')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .order('created_at', { ascending: true });
+
+  return unwrapList(response, 'Unable to load company members');
+};
+
+export const getCompanyMemberById = async (
+  companyId: string,
+  memberId: string,
+): Promise<CompanyMember> => {
+  const response = await supabase
+    .from<CompanyMember>('company_members')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(memberId, 'memberId'))
+    .maybeSingle();
+
+  const member = unwrapMaybeSingle(response, 'Unable to load company member');
+
+  if (!member) {
+    throw new RepositoryError('Company member not found', { status: 404 });
+  }
+
+  return member;
+};
+
+export const createCompanyMember = async (
+  companyId: string,
+  payload: CompanyMemberInsert,
+): Promise<CompanyMember> => {
+  const response = await supabase
+    .from<CompanyMember>('company_members')
+    .insert({ ...payload, company_id: ensureCompanyScope(companyId) })
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to create company member');
+};
+
+export const replaceCompanyMember = async (
+  companyId: string,
+  memberId: string,
+  payload: CompanyMemberReplace,
+): Promise<CompanyMember> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<CompanyMember>('company_members')
+    .update({ ...payload, company_id: scopedCompanyId })
+    .eq('id', ensureIdentifier(memberId, 'memberId'))
+    .eq('company_id', scopedCompanyId)
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to replace company member');
+};
+
+export const updateCompanyMember = async (
+  companyId: string,
+  memberId: string,
+  payload: CompanyMemberUpdate,
+): Promise<CompanyMember> => {
+  const response = await supabase
+    .from<CompanyMember>('company_members')
+    .update(payload)
+    .eq('id', ensureIdentifier(memberId, 'memberId'))
+    .eq('company_id', ensureCompanyScope(companyId))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to update company member');
+};
+
+export const deleteCompanyMember = async (
+  companyId: string,
+  memberId: string,
+): Promise<void> => {
+  const response = await supabase
+    .from('company_members')
+    .delete()
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(memberId, 'memberId'));
+
+  ensureNoError(response, 'Unable to delete company member');
+};
+
+export const getAuditLogs = async (companyId: string): Promise<AuditLog[]> => {
+  const response = await supabase
+    .from<AuditLog>('audit_logs')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .order('created_at', { ascending: false });
+
+  return unwrapList(response, 'Unable to load audit logs');
+};
+
+export const getAuditLogById = async (
+  companyId: string,
+  logId: string,
+): Promise<AuditLog> => {
+  const response = await supabase
+    .from<AuditLog>('audit_logs')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(logId, 'logId'))
+    .maybeSingle();
+
+  const log = unwrapMaybeSingle(response, 'Unable to load audit log');
+
+  if (!log) {
+    throw new RepositoryError('Audit log entry not found', { status: 404 });
+  }
+
+  return log;
+};
+
+export const createAuditLog = async (
+  companyId: string,
+  payload: AuditLogInsert,
+): Promise<AuditLog> => {
+  const response = await supabase
+    .from<AuditLog>('audit_logs')
+    .insert({ ...payload, company_id: ensureCompanyScope(companyId) })
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to create audit log entry');
+};
+
+export const replaceAuditLog = async (
+  companyId: string,
+  logId: string,
+  payload: AuditLogReplace,
+): Promise<AuditLog> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<AuditLog>('audit_logs')
+    .update({ ...payload, company_id: scopedCompanyId })
+    .eq('id', ensureIdentifier(logId, 'logId'))
+    .eq('company_id', scopedCompanyId)
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to replace audit log entry');
+};
+
+export const updateAuditLog = async (
+  companyId: string,
+  logId: string,
+  payload: AuditLogUpdate,
+): Promise<AuditLog> => {
+  const response = await supabase
+    .from<AuditLog>('audit_logs')
+    .update(payload)
+    .eq('id', ensureIdentifier(logId, 'logId'))
+    .eq('company_id', ensureCompanyScope(companyId))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to update audit log entry');
+};
+
+export const deleteAuditLog = async (companyId: string, logId: string): Promise<void> => {
+  const response = await supabase
+    .from('audit_logs')
+    .delete()
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(logId, 'logId'));
+
+  ensureNoError(response, 'Unable to delete audit log entry');
+};

--- a/lib/repositories/documentStorageRepository.ts
+++ b/lib/repositories/documentStorageRepository.ts
@@ -1,0 +1,132 @@
+import { uploadFile, createSignedUrl, removeFiles } from '@/lib/adapters/supabaseStorage';
+import {
+  ensureMutation,
+  RepositoryError,
+  unwrapMaybeSingle,
+} from '@/lib/adapters/supabaseAdapter';
+import { ensureCompanyScope, ensureIdentifier } from '@/lib/middlewares/ensureCompanyScope';
+import { supabase } from '@/lib/supabase';
+import {
+  deleteDocumentFile,
+  getDocumentFileById,
+} from '@/lib/repositories/documentsRepository';
+import type {
+  DocumentFile,
+  DocumentFileInsert,
+} from '@/types/db';
+import type { SignedUrlOptions, SignedUrlResult, StorageFile, StorageUploadOptions } from '@/types/storage';
+
+const sanitizeFileName = (fileName: string): string => fileName.trim().replace(/\s+/g, '-');
+
+const buildDocumentFilePath = ({
+  companyId,
+  documentId,
+  version,
+  fileName,
+}: {
+  companyId: string;
+  documentId: string;
+  version: number;
+  fileName: string;
+}): string => `company/${companyId}/documents/${documentId}/${version}/${sanitizeFileName(fileName)}`;
+
+const fetchLatestVersion = async (documentId: string): Promise<number> => {
+  const response = await supabase
+    .from<{ version: number }>('document_files')
+    .select('version')
+    .eq('document_id', ensureIdentifier(documentId, 'documentId'))
+    .order('version', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const record = unwrapMaybeSingle(response, 'Unable to determine document file version');
+  return record?.version ?? 0;
+};
+
+export const getNextDocumentFileVersion = async (
+  documentId: string,
+): Promise<number> => {
+  const latest = await fetchLatestVersion(documentId);
+  return latest + 1;
+};
+
+export interface UploadDocumentFileParams {
+  companyId: string;
+  documentId: string;
+  uploadedBy?: string | null;
+  templateId?: string | null;
+  version?: number;
+  file: StorageFile;
+  fileName: string;
+  fileSize?: number | null;
+  contentType?: string;
+  checksum?: string | null;
+  storageOptions?: StorageUploadOptions;
+}
+
+export const uploadDocumentFile = async (
+  params: UploadDocumentFileParams,
+): Promise<DocumentFile> => {
+  const companyId = ensureCompanyScope(params.companyId);
+  const documentId = ensureIdentifier(params.documentId, 'documentId');
+  const version = params.version ?? (await getNextDocumentFileVersion(documentId));
+  const path = buildDocumentFilePath({
+    companyId,
+    documentId,
+    version,
+    fileName: params.fileName,
+  });
+
+  await uploadFile('documents', path, params.file, {
+    cacheControl: params.storageOptions?.cacheControl,
+    contentType: params.contentType,
+    metadata: params.storageOptions?.metadata,
+    upsert: params.storageOptions?.upsert ?? false,
+  });
+
+  const payload: DocumentFileInsert = {
+    company_id: companyId,
+    document_id: documentId,
+    template_id: params.templateId ?? null,
+    file_path: path,
+    file_size: params.fileSize ?? null,
+    content_type: params.contentType ?? null,
+    version,
+    uploaded_by: params.uploadedBy ?? null,
+    checksum: params.checksum ?? null,
+  };
+
+  const response = await supabase
+    .from<DocumentFile>('document_files')
+    .insert(payload)
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to persist document file metadata');
+};
+
+export const createDocumentFileSignedUrl = async (
+  path: string,
+  options: SignedUrlOptions,
+): Promise<SignedUrlResult> => {
+  const filePath = ensureIdentifier(path, 'filePath');
+  return createSignedUrl('documents', filePath, options);
+};
+
+export const removeDocumentFileAssets = async (paths: string[]): Promise<void> => {
+  await removeFiles('documents', paths);
+};
+
+export const deleteDocumentFileWithAsset = async (
+  companyId: string,
+  fileId: string,
+): Promise<void> => {
+  const record = await getDocumentFileById(companyId, fileId);
+
+  if (!record.file_path) {
+    throw new RepositoryError('Document file path is missing', { status: 400 });
+  }
+
+  await removeDocumentFileAssets([record.file_path]);
+  await deleteDocumentFile(companyId, fileId);
+};

--- a/lib/repositories/documentsRepository.ts
+++ b/lib/repositories/documentsRepository.ts
@@ -1,0 +1,402 @@
+import { supabase } from '@/lib/supabase';
+import {
+  ensureMutation,
+  ensureNoError,
+  RepositoryError,
+  unwrapList,
+  unwrapMaybeSingle,
+} from '@/lib/adapters/supabaseAdapter';
+import { ensureCompanyScope, ensureIdentifier } from '@/lib/middlewares/ensureCompanyScope';
+import type {
+  Document,
+  DocumentCategory,
+  DocumentCategoryInsert,
+  DocumentCategoryReplace,
+  DocumentCategoryUpdate,
+  DocumentFile,
+  DocumentFileInsert,
+  DocumentFileReplace,
+  DocumentFileUpdate,
+  DocumentInsert,
+  DocumentReplace,
+  DocumentTemplate,
+  DocumentTemplateInsert,
+  DocumentTemplateReplace,
+  DocumentTemplateUpdate,
+  DocumentUpdate,
+} from '@/types/db';
+
+export const getDocumentCategories = async (
+  companyId: string,
+): Promise<DocumentCategory[]> => {
+  const response = await supabase
+    .from<DocumentCategory>('document_categories')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .order('created_at', { ascending: true });
+
+  return unwrapList(response, 'Unable to load document categories');
+};
+
+export const getDocumentCategoryById = async (
+  companyId: string,
+  categoryId: string,
+): Promise<DocumentCategory> => {
+  const response = await supabase
+    .from<DocumentCategory>('document_categories')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(categoryId, 'categoryId'))
+    .maybeSingle();
+
+  const category = unwrapMaybeSingle(response, 'Unable to load document category');
+
+  if (!category) {
+    throw new RepositoryError('Document category not found', { status: 404 });
+  }
+
+  return category;
+};
+
+export const createDocumentCategory = async (
+  companyId: string,
+  payload: DocumentCategoryInsert,
+): Promise<DocumentCategory> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<DocumentCategory>('document_categories')
+    .insert({ ...payload, company_id: scopedCompanyId })
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to create document category');
+};
+
+export const replaceDocumentCategory = async (
+  companyId: string,
+  categoryId: string,
+  payload: DocumentCategoryReplace,
+): Promise<DocumentCategory> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<DocumentCategory>('document_categories')
+    .update({ ...payload, company_id: scopedCompanyId })
+    .eq('company_id', scopedCompanyId)
+    .eq('id', ensureIdentifier(categoryId, 'categoryId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to replace document category');
+};
+
+export const updateDocumentCategory = async (
+  companyId: string,
+  categoryId: string,
+  payload: DocumentCategoryUpdate,
+): Promise<DocumentCategory> => {
+  const response = await supabase
+    .from<DocumentCategory>('document_categories')
+    .update(payload)
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(categoryId, 'categoryId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to update document category');
+};
+
+export const deleteDocumentCategory = async (
+  companyId: string,
+  categoryId: string,
+): Promise<void> => {
+  const response = await supabase
+    .from('document_categories')
+    .delete()
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(categoryId, 'categoryId'));
+
+  ensureNoError(response, 'Unable to delete document category');
+};
+
+export const getDocumentTemplates = async (
+  companyId: string,
+): Promise<DocumentTemplate[]> => {
+  const response = await supabase
+    .from<DocumentTemplate>('document_templates')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .order('created_at', { ascending: true });
+
+  return unwrapList(response, 'Unable to load document templates');
+};
+
+export const getDocumentTemplateById = async (
+  companyId: string,
+  templateId: string,
+): Promise<DocumentTemplate> => {
+  const response = await supabase
+    .from<DocumentTemplate>('document_templates')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(templateId, 'templateId'))
+    .maybeSingle();
+
+  const template = unwrapMaybeSingle(response, 'Unable to load document template');
+
+  if (!template) {
+    throw new RepositoryError('Document template not found', { status: 404 });
+  }
+
+  return template;
+};
+
+export const createDocumentTemplate = async (
+  companyId: string,
+  payload: DocumentTemplateInsert,
+): Promise<DocumentTemplate> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<DocumentTemplate>('document_templates')
+    .insert({ ...payload, company_id: scopedCompanyId })
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to create document template');
+};
+
+export const replaceDocumentTemplate = async (
+  companyId: string,
+  templateId: string,
+  payload: DocumentTemplateReplace,
+): Promise<DocumentTemplate> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<DocumentTemplate>('document_templates')
+    .update({ ...payload, company_id: scopedCompanyId })
+    .eq('company_id', scopedCompanyId)
+    .eq('id', ensureIdentifier(templateId, 'templateId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to replace document template');
+};
+
+export const updateDocumentTemplate = async (
+  companyId: string,
+  templateId: string,
+  payload: DocumentTemplateUpdate,
+): Promise<DocumentTemplate> => {
+  const response = await supabase
+    .from<DocumentTemplate>('document_templates')
+    .update(payload)
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(templateId, 'templateId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to update document template');
+};
+
+export const deleteDocumentTemplate = async (
+  companyId: string,
+  templateId: string,
+): Promise<void> => {
+  const response = await supabase
+    .from('document_templates')
+    .delete()
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(templateId, 'templateId'));
+
+  ensureNoError(response, 'Unable to delete document template');
+};
+
+export const getDocuments = async (
+  companyId: string,
+): Promise<Document[]> => {
+  const response = await supabase
+    .from<Document>('documents')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .order('issued_at', { ascending: false });
+
+  return unwrapList(response, 'Unable to load documents');
+};
+
+export const getDocumentById = async (
+  companyId: string,
+  documentId: string,
+): Promise<Document> => {
+  const response = await supabase
+    .from<Document>('documents')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(documentId, 'documentId'))
+    .maybeSingle();
+
+  const document = unwrapMaybeSingle(response, 'Unable to load document');
+
+  if (!document) {
+    throw new RepositoryError('Document not found', { status: 404 });
+  }
+
+  return document;
+};
+
+export const createDocument = async (
+  companyId: string,
+  payload: DocumentInsert,
+): Promise<Document> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<Document>('documents')
+    .insert({ ...payload, company_id: scopedCompanyId })
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to create document');
+};
+
+export const replaceDocument = async (
+  companyId: string,
+  documentId: string,
+  payload: DocumentReplace,
+): Promise<Document> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<Document>('documents')
+    .update({ ...payload, company_id: scopedCompanyId })
+    .eq('company_id', scopedCompanyId)
+    .eq('id', ensureIdentifier(documentId, 'documentId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to replace document');
+};
+
+export const updateDocument = async (
+  companyId: string,
+  documentId: string,
+  payload: DocumentUpdate,
+): Promise<Document> => {
+  const response = await supabase
+    .from<Document>('documents')
+    .update(payload)
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(documentId, 'documentId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to update document');
+};
+
+export const deleteDocument = async (
+  companyId: string,
+  documentId: string,
+): Promise<void> => {
+  const response = await supabase
+    .from('documents')
+    .delete()
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(documentId, 'documentId'));
+
+  ensureNoError(response, 'Unable to delete document');
+};
+
+export const getDocumentFiles = async (
+  companyId: string,
+  documentId?: string,
+): Promise<DocumentFile[]> => {
+  let query = supabase
+    .from<DocumentFile>('document_files')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .order('uploaded_at', { ascending: false });
+
+  if (documentId) {
+    query = query.eq('document_id', ensureIdentifier(documentId, 'documentId'));
+  }
+
+  const response = await query;
+
+  return unwrapList(response, 'Unable to load document files');
+};
+
+export const getDocumentFileById = async (
+  companyId: string,
+  fileId: string,
+): Promise<DocumentFile> => {
+  const response = await supabase
+    .from<DocumentFile>('document_files')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(fileId, 'fileId'))
+    .maybeSingle();
+
+  const file = unwrapMaybeSingle(response, 'Unable to load document file');
+
+  if (!file) {
+    throw new RepositoryError('Document file not found', { status: 404 });
+  }
+
+  return file;
+};
+
+export const createDocumentFile = async (
+  companyId: string,
+  payload: DocumentFileInsert,
+): Promise<DocumentFile> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<DocumentFile>('document_files')
+    .insert({ ...payload, company_id: scopedCompanyId })
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to create document file');
+};
+
+export const replaceDocumentFile = async (
+  companyId: string,
+  fileId: string,
+  payload: DocumentFileReplace,
+): Promise<DocumentFile> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<DocumentFile>('document_files')
+    .update({ ...payload, company_id: scopedCompanyId })
+    .eq('company_id', scopedCompanyId)
+    .eq('id', ensureIdentifier(fileId, 'fileId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to replace document file');
+};
+
+export const updateDocumentFile = async (
+  companyId: string,
+  fileId: string,
+  payload: DocumentFileUpdate,
+): Promise<DocumentFile> => {
+  const response = await supabase
+    .from<DocumentFile>('document_files')
+    .update(payload)
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(fileId, 'fileId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to update document file');
+};
+
+export const deleteDocumentFile = async (
+  companyId: string,
+  fileId: string,
+): Promise<void> => {
+  const response = await supabase
+    .from('document_files')
+    .delete()
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(fileId, 'fileId'));
+
+  ensureNoError(response, 'Unable to delete document file');
+};

--- a/lib/repositories/documentsRepository.ts
+++ b/lib/repositories/documentsRepository.ts
@@ -242,6 +242,20 @@ export const getDocumentById = async (
   return document;
 };
 
+export const getDocumentsForEmployee = async (
+  companyId: string,
+  employeeId: string,
+): Promise<Document[]> => {
+  const response = await supabase
+    .from<Document>('documents')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('employee_id', ensureIdentifier(employeeId, 'employeeId'))
+    .order('issued_at', { ascending: false });
+
+  return unwrapList(response, 'Unable to load employee documents');
+};
+
 export const createDocument = async (
   companyId: string,
   payload: DocumentInsert,
@@ -399,4 +413,23 @@ export const deleteDocumentFile = async (
     .eq('id', ensureIdentifier(fileId, 'fileId'));
 
   ensureNoError(response, 'Unable to delete document file');
+};
+
+export const getDocumentFilesByDocumentIds = async (
+  companyId: string,
+  documentIds: string[],
+): Promise<DocumentFile[]> => {
+  if (!documentIds.length) {
+    return [];
+  }
+
+  const response = await supabase
+    .from<DocumentFile>('document_files')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .in('document_id', documentIds)
+    .order('version', { ascending: false })
+    .order('uploaded_at', { ascending: false });
+
+  return unwrapList(response, 'Unable to load document files');
 };

--- a/lib/repositories/eventsRepository.ts
+++ b/lib/repositories/eventsRepository.ts
@@ -1,0 +1,300 @@
+import { supabase } from '@/lib/supabase';
+import {
+  ensureMutation,
+  ensureNoError,
+  RepositoryError,
+  unwrapList,
+  unwrapMaybeSingle,
+} from '@/lib/adapters/supabaseAdapter';
+import { ensureCompanyScope, ensureIdentifier } from '@/lib/middlewares/ensureCompanyScope';
+import type {
+  EventAttendee,
+  EventAttendeeInsert,
+  EventAttendeeReplace,
+  EventAttendeeUpdate,
+  EventInsert,
+  EventRecord,
+  EventReplace,
+  EventUpdate,
+  HolidayCalendar,
+  HolidayCalendarInsert,
+  HolidayCalendarReplace,
+  HolidayCalendarUpdate,
+} from '@/types/db';
+
+export const getEvents = async (companyId: string): Promise<EventRecord[]> => {
+  const response = await supabase
+    .from<EventRecord>('events')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .order('start_at', { ascending: true });
+
+  return unwrapList(response, 'Unable to load events');
+};
+
+export const getEventById = async (
+  companyId: string,
+  eventId: string,
+): Promise<EventRecord> => {
+  const response = await supabase
+    .from<EventRecord>('events')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(eventId, 'eventId'))
+    .maybeSingle();
+
+  const event = unwrapMaybeSingle(response, 'Unable to load event');
+
+  if (!event) {
+    throw new RepositoryError('Event not found', { status: 404 });
+  }
+
+  return event;
+};
+
+export const createEvent = async (
+  companyId: string,
+  payload: EventInsert,
+): Promise<EventRecord> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<EventRecord>('events')
+    .insert({ ...payload, company_id: scopedCompanyId })
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to create event');
+};
+
+export const replaceEvent = async (
+  companyId: string,
+  eventId: string,
+  payload: EventReplace,
+): Promise<EventRecord> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<EventRecord>('events')
+    .update({ ...payload, company_id: scopedCompanyId })
+    .eq('company_id', scopedCompanyId)
+    .eq('id', ensureIdentifier(eventId, 'eventId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to replace event');
+};
+
+export const updateEvent = async (
+  companyId: string,
+  eventId: string,
+  payload: EventUpdate,
+): Promise<EventRecord> => {
+  const response = await supabase
+    .from<EventRecord>('events')
+    .update(payload)
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(eventId, 'eventId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to update event');
+};
+
+export const deleteEvent = async (
+  companyId: string,
+  eventId: string,
+): Promise<void> => {
+  const response = await supabase
+    .from('events')
+    .delete()
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(eventId, 'eventId'));
+
+  ensureNoError(response, 'Unable to delete event');
+};
+
+export const getEventAttendees = async (
+  companyId: string,
+  eventId: string,
+): Promise<EventAttendee[]> => {
+  const scopedEventId = ensureIdentifier(eventId, 'eventId');
+  const response = await supabase
+    .from<EventAttendee>('event_attendees')
+    .select('*')
+    .eq('event_id', scopedEventId)
+    .order('id', { ascending: true });
+
+  const attendees = unwrapList(response, 'Unable to load event attendees');
+
+  await getEventById(companyId, scopedEventId);
+  return attendees;
+};
+
+export const getEventAttendeeById = async (
+  eventId: string,
+  attendeeId: string,
+): Promise<EventAttendee> => {
+  const response = await supabase
+    .from<EventAttendee>('event_attendees')
+    .select('*')
+    .eq('event_id', ensureIdentifier(eventId, 'eventId'))
+    .eq('id', ensureIdentifier(attendeeId, 'attendeeId'))
+    .maybeSingle();
+
+  const attendee = unwrapMaybeSingle(response, 'Unable to load event attendee');
+
+  if (!attendee) {
+    throw new RepositoryError('Event attendee not found', { status: 404 });
+  }
+
+  return attendee;
+};
+
+export const createEventAttendee = async (
+  eventId: string,
+  payload: EventAttendeeInsert,
+): Promise<EventAttendee> => {
+  const response = await supabase
+    .from<EventAttendee>('event_attendees')
+    .insert({ ...payload, event_id: ensureIdentifier(eventId, 'eventId') })
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to create event attendee');
+};
+
+export const replaceEventAttendee = async (
+  eventId: string,
+  attendeeId: string,
+  payload: EventAttendeeReplace,
+): Promise<EventAttendee> => {
+  const response = await supabase
+    .from<EventAttendee>('event_attendees')
+    .update({ ...payload, event_id: ensureIdentifier(eventId, 'eventId') })
+    .eq('event_id', ensureIdentifier(eventId, 'eventId'))
+    .eq('id', ensureIdentifier(attendeeId, 'attendeeId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to replace event attendee');
+};
+
+export const updateEventAttendee = async (
+  eventId: string,
+  attendeeId: string,
+  payload: EventAttendeeUpdate,
+): Promise<EventAttendee> => {
+  const response = await supabase
+    .from<EventAttendee>('event_attendees')
+    .update(payload)
+    .eq('event_id', ensureIdentifier(eventId, 'eventId'))
+    .eq('id', ensureIdentifier(attendeeId, 'attendeeId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to update event attendee');
+};
+
+export const deleteEventAttendee = async (
+  eventId: string,
+  attendeeId: string,
+): Promise<void> => {
+  const response = await supabase
+    .from('event_attendees')
+    .delete()
+    .eq('event_id', ensureIdentifier(eventId, 'eventId'))
+    .eq('id', ensureIdentifier(attendeeId, 'attendeeId'));
+
+  ensureNoError(response, 'Unable to delete event attendee');
+};
+
+export const getHolidayCalendar = async (
+  companyId: string,
+): Promise<HolidayCalendar[]> => {
+  const response = await supabase
+    .from<HolidayCalendar>('holiday_calendars')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .order('date', { ascending: true });
+
+  return unwrapList(response, 'Unable to load holiday calendars');
+};
+
+export const getHolidayCalendarEntryById = async (
+  companyId: string,
+  entryId: string,
+): Promise<HolidayCalendar> => {
+  const response = await supabase
+    .from<HolidayCalendar>('holiday_calendars')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(entryId, 'entryId'))
+    .maybeSingle();
+
+  const holiday = unwrapMaybeSingle(response, 'Unable to load holiday calendar entry');
+
+  if (!holiday) {
+    throw new RepositoryError('Holiday calendar entry not found', { status: 404 });
+  }
+
+  return holiday;
+};
+
+export const createHolidayCalendarEntry = async (
+  companyId: string,
+  payload: HolidayCalendarInsert,
+): Promise<HolidayCalendar> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<HolidayCalendar>('holiday_calendars')
+    .insert({ ...payload, company_id: scopedCompanyId })
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to create holiday calendar entry');
+};
+
+export const replaceHolidayCalendarEntry = async (
+  companyId: string,
+  entryId: string,
+  payload: HolidayCalendarReplace,
+): Promise<HolidayCalendar> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<HolidayCalendar>('holiday_calendars')
+    .update({ ...payload, company_id: scopedCompanyId })
+    .eq('company_id', scopedCompanyId)
+    .eq('id', ensureIdentifier(entryId, 'entryId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to replace holiday calendar entry');
+};
+
+export const updateHolidayCalendarEntry = async (
+  companyId: string,
+  entryId: string,
+  payload: HolidayCalendarUpdate,
+): Promise<HolidayCalendar> => {
+  const response = await supabase
+    .from<HolidayCalendar>('holiday_calendars')
+    .update(payload)
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(entryId, 'entryId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to update holiday calendar entry');
+};
+
+export const deleteHolidayCalendarEntry = async (
+  companyId: string,
+  entryId: string,
+): Promise<void> => {
+  const response = await supabase
+    .from('holiday_calendars')
+    .delete()
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(entryId, 'entryId'));
+
+  ensureNoError(response, 'Unable to delete holiday calendar entry');
+};

--- a/lib/repositories/index.ts
+++ b/lib/repositories/index.ts
@@ -3,3 +3,7 @@ export * from './userRepository';
 export * from './documentsRepository';
 export * from './eventsRepository';
 export * from './notificationsRepository';
+export * from './paychecksRepository';
+export * from './documentStorageRepository';
+export * from './paychecksStorageRepository';
+export * from './avatarStorageRepository';

--- a/lib/repositories/index.ts
+++ b/lib/repositories/index.ts
@@ -1,0 +1,5 @@
+export * from './companyRepository';
+export * from './userRepository';
+export * from './documentsRepository';
+export * from './eventsRepository';
+export * from './notificationsRepository';

--- a/lib/repositories/notificationsRepository.ts
+++ b/lib/repositories/notificationsRepository.ts
@@ -1,0 +1,284 @@
+import { supabase } from '@/lib/supabase';
+import {
+  ensureMutation,
+  ensureNoError,
+  RepositoryError,
+  unwrapList,
+  unwrapMaybeSingle,
+} from '@/lib/adapters/supabaseAdapter';
+import { ensureCompanyScope, ensureIdentifier } from '@/lib/middlewares/ensureCompanyScope';
+import type {
+  NotificationChannel,
+  NotificationChannelInsert,
+  NotificationChannelReplace,
+  NotificationChannelUpdate,
+  NotificationDelivery,
+  NotificationDeliveryInsert,
+  NotificationDeliveryReplace,
+  NotificationDeliveryUpdate,
+  NotificationInsert,
+  NotificationRecord,
+  NotificationReplace,
+  NotificationUpdate,
+} from '@/types/db';
+
+export const getNotificationChannels = async (
+  userId: string,
+  companyId?: string | null,
+): Promise<NotificationChannel[]> => {
+  let query = supabase
+    .from<NotificationChannel>('notification_channels')
+    .select('*')
+    .eq('user_id', ensureIdentifier(userId, 'userId'))
+    .order('created_at', { ascending: true });
+
+  if (companyId) {
+    query = query.eq('company_id', companyId);
+  }
+
+  const response = await query;
+
+  return unwrapList(response, 'Unable to load notification channels');
+};
+
+export const getNotificationChannelById = async (
+  channelId: string,
+): Promise<NotificationChannel> => {
+  const response = await supabase
+    .from<NotificationChannel>('notification_channels')
+    .select('*')
+    .eq('id', ensureIdentifier(channelId, 'channelId'))
+    .maybeSingle();
+
+  const channel = unwrapMaybeSingle(response, 'Unable to load notification channel');
+
+  if (!channel) {
+    throw new RepositoryError('Notification channel not found', { status: 404 });
+  }
+
+  return channel;
+};
+
+export const createNotificationChannel = async (
+  payload: NotificationChannelInsert,
+): Promise<NotificationChannel> => {
+  const response = await supabase
+    .from<NotificationChannel>('notification_channels')
+    .insert(payload)
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to create notification channel');
+};
+
+export const replaceNotificationChannel = async (
+  channelId: string,
+  payload: NotificationChannelReplace,
+): Promise<NotificationChannel> => {
+  const response = await supabase
+    .from<NotificationChannel>('notification_channels')
+    .update(payload)
+    .eq('id', ensureIdentifier(channelId, 'channelId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to replace notification channel');
+};
+
+export const updateNotificationChannel = async (
+  channelId: string,
+  payload: NotificationChannelUpdate,
+): Promise<NotificationChannel> => {
+  const response = await supabase
+    .from<NotificationChannel>('notification_channels')
+    .update(payload)
+    .eq('id', ensureIdentifier(channelId, 'channelId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to update notification channel');
+};
+
+export const deleteNotificationChannel = async (
+  channelId: string,
+): Promise<void> => {
+  const response = await supabase
+    .from('notification_channels')
+    .delete()
+    .eq('id', ensureIdentifier(channelId, 'channelId'));
+
+  ensureNoError(response, 'Unable to delete notification channel');
+};
+
+export const getNotifications = async (
+  companyId: string,
+): Promise<NotificationRecord[]> => {
+  const response = await supabase
+    .from<NotificationRecord>('notifications')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .order('created_at', { ascending: false });
+
+  return unwrapList(response, 'Unable to load notifications');
+};
+
+export const getNotificationById = async (
+  companyId: string,
+  notificationId: string,
+): Promise<NotificationRecord> => {
+  const response = await supabase
+    .from<NotificationRecord>('notifications')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(notificationId, 'notificationId'))
+    .maybeSingle();
+
+  const notification = unwrapMaybeSingle(response, 'Unable to load notification');
+
+  if (!notification) {
+    throw new RepositoryError('Notification not found', { status: 404 });
+  }
+
+  return notification;
+};
+
+export const createNotification = async (
+  companyId: string,
+  payload: NotificationInsert,
+): Promise<NotificationRecord> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<NotificationRecord>('notifications')
+    .insert({ ...payload, company_id: scopedCompanyId })
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to create notification');
+};
+
+export const replaceNotification = async (
+  companyId: string,
+  notificationId: string,
+  payload: NotificationReplace,
+): Promise<NotificationRecord> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<NotificationRecord>('notifications')
+    .update({ ...payload, company_id: scopedCompanyId })
+    .eq('company_id', scopedCompanyId)
+    .eq('id', ensureIdentifier(notificationId, 'notificationId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to replace notification');
+};
+
+export const updateNotification = async (
+  companyId: string,
+  notificationId: string,
+  payload: NotificationUpdate,
+): Promise<NotificationRecord> => {
+  const response = await supabase
+    .from<NotificationRecord>('notifications')
+    .update(payload)
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(notificationId, 'notificationId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to update notification');
+};
+
+export const deleteNotification = async (
+  companyId: string,
+  notificationId: string,
+): Promise<void> => {
+  const response = await supabase
+    .from('notifications')
+    .delete()
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(notificationId, 'notificationId'));
+
+  ensureNoError(response, 'Unable to delete notification');
+};
+
+export const getNotificationDeliveries = async (
+  notificationId: string,
+): Promise<NotificationDelivery[]> => {
+  const response = await supabase
+    .from<NotificationDelivery>('notification_deliveries')
+    .select('*')
+    .eq('notification_id', ensureIdentifier(notificationId, 'notificationId'))
+    .order('created_at', { ascending: true });
+
+  return unwrapList(response, 'Unable to load notification deliveries');
+};
+
+export const getNotificationDeliveryById = async (
+  deliveryId: string,
+): Promise<NotificationDelivery> => {
+  const response = await supabase
+    .from<NotificationDelivery>('notification_deliveries')
+    .select('*')
+    .eq('id', ensureIdentifier(deliveryId, 'deliveryId'))
+    .maybeSingle();
+
+  const delivery = unwrapMaybeSingle(response, 'Unable to load notification delivery');
+
+  if (!delivery) {
+    throw new RepositoryError('Notification delivery not found', { status: 404 });
+  }
+
+  return delivery;
+};
+
+export const createNotificationDelivery = async (
+  payload: NotificationDeliveryInsert,
+): Promise<NotificationDelivery> => {
+  const response = await supabase
+    .from<NotificationDelivery>('notification_deliveries')
+    .insert(payload)
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to create notification delivery');
+};
+
+export const replaceNotificationDelivery = async (
+  deliveryId: string,
+  payload: NotificationDeliveryReplace,
+): Promise<NotificationDelivery> => {
+  const response = await supabase
+    .from<NotificationDelivery>('notification_deliveries')
+    .update(payload)
+    .eq('id', ensureIdentifier(deliveryId, 'deliveryId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to replace notification delivery');
+};
+
+export const updateNotificationDelivery = async (
+  deliveryId: string,
+  payload: NotificationDeliveryUpdate,
+): Promise<NotificationDelivery> => {
+  const response = await supabase
+    .from<NotificationDelivery>('notification_deliveries')
+    .update(payload)
+    .eq('id', ensureIdentifier(deliveryId, 'deliveryId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to update notification delivery');
+};
+
+export const deleteNotificationDelivery = async (
+  deliveryId: string,
+): Promise<void> => {
+  const response = await supabase
+    .from('notification_deliveries')
+    .delete()
+    .eq('id', ensureIdentifier(deliveryId, 'deliveryId'));
+
+  ensureNoError(response, 'Unable to delete notification delivery');
+};

--- a/lib/repositories/paychecksRepository.ts
+++ b/lib/repositories/paychecksRepository.ts
@@ -1,0 +1,217 @@
+import { supabase } from '@/lib/supabase';
+import {
+  ensureMutation,
+  ensureNoError,
+  RepositoryError,
+  unwrapList,
+  unwrapMaybeSingle,
+} from '@/lib/adapters/supabaseAdapter';
+import { ensureCompanyScope, ensureIdentifier } from '@/lib/middlewares/ensureCompanyScope';
+import type {
+  Paycheck,
+  PaycheckInsert,
+  PaycheckReplace,
+  PaycheckSignatureEvent,
+  PaycheckSignatureEventInsert,
+  PaycheckSignatureEventReplace,
+  PaycheckSignatureEventUpdate,
+  PaycheckUpdate,
+} from '@/types/db';
+
+export const getPaychecks = async (companyId: string): Promise<Paycheck[]> => {
+  const response = await supabase
+    .from<Paycheck>('paychecks')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .order('issued_at', { ascending: false });
+
+  return unwrapList(response, 'Unable to load paychecks');
+};
+
+export const getPaychecksForEmployee = async (
+  companyId: string,
+  employeeId: string,
+): Promise<Paycheck[]> => {
+  const response = await supabase
+    .from<Paycheck>('paychecks')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('employee_id', ensureIdentifier(employeeId, 'employeeId'))
+    .order('issued_at', { ascending: false });
+
+  return unwrapList(response, 'Unable to load paychecks for employee');
+};
+
+export const getPaycheckById = async (
+  companyId: string,
+  paycheckId: string,
+): Promise<Paycheck> => {
+  const response = await supabase
+    .from<Paycheck>('paychecks')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(paycheckId, 'paycheckId'))
+    .maybeSingle();
+
+  const paycheck = unwrapMaybeSingle(response, 'Unable to load paycheck');
+
+  if (!paycheck) {
+    throw new RepositoryError('Paycheck not found', { status: 404 });
+  }
+
+  return paycheck;
+};
+
+export const createPaycheck = async (
+  companyId: string,
+  payload: PaycheckInsert,
+): Promise<Paycheck> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<Paycheck>('paychecks')
+    .insert({ ...payload, company_id: scopedCompanyId })
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to create paycheck');
+};
+
+export const replacePaycheck = async (
+  companyId: string,
+  paycheckId: string,
+  payload: PaycheckReplace,
+): Promise<Paycheck> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<Paycheck>('paychecks')
+    .update({ ...payload, company_id: scopedCompanyId })
+    .eq('company_id', scopedCompanyId)
+    .eq('id', ensureIdentifier(paycheckId, 'paycheckId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to replace paycheck');
+};
+
+export const updatePaycheck = async (
+  companyId: string,
+  paycheckId: string,
+  payload: PaycheckUpdate,
+): Promise<Paycheck> => {
+  const response = await supabase
+    .from<Paycheck>('paychecks')
+    .update(payload)
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(paycheckId, 'paycheckId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to update paycheck');
+};
+
+export const deletePaycheck = async (
+  companyId: string,
+  paycheckId: string,
+): Promise<void> => {
+  const response = await supabase
+    .from('paychecks')
+    .delete()
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(paycheckId, 'paycheckId'));
+
+  ensureNoError(response, 'Unable to delete paycheck');
+};
+
+export const getPaycheckSignatureEvents = async (
+  companyId: string,
+  paycheckId: string,
+): Promise<PaycheckSignatureEvent[]> => {
+  const response = await supabase
+    .from<PaycheckSignatureEvent>('paycheck_signature_events')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('paycheck_id', ensureIdentifier(paycheckId, 'paycheckId'))
+    .order('created_at', { ascending: true });
+
+  return unwrapList(response, 'Unable to load paycheck signature events');
+};
+
+export const getPaycheckSignatureEventById = async (
+  companyId: string,
+  eventId: string,
+): Promise<PaycheckSignatureEvent> => {
+  const response = await supabase
+    .from<PaycheckSignatureEvent>('paycheck_signature_events')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(eventId, 'eventId'))
+    .maybeSingle();
+
+  const event = unwrapMaybeSingle(response, 'Unable to load paycheck signature event');
+
+  if (!event) {
+    throw new RepositoryError('Paycheck signature event not found', { status: 404 });
+  }
+
+  return event;
+};
+
+export const createPaycheckSignatureEvent = async (
+  companyId: string,
+  payload: PaycheckSignatureEventInsert,
+): Promise<PaycheckSignatureEvent> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<PaycheckSignatureEvent>('paycheck_signature_events')
+    .insert({ ...payload, company_id: scopedCompanyId })
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to create paycheck signature event');
+};
+
+export const replacePaycheckSignatureEvent = async (
+  companyId: string,
+  eventId: string,
+  payload: PaycheckSignatureEventReplace,
+): Promise<PaycheckSignatureEvent> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<PaycheckSignatureEvent>('paycheck_signature_events')
+    .update({ ...payload, company_id: scopedCompanyId })
+    .eq('company_id', scopedCompanyId)
+    .eq('id', ensureIdentifier(eventId, 'eventId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to replace paycheck signature event');
+};
+
+export const updatePaycheckSignatureEvent = async (
+  companyId: string,
+  eventId: string,
+  payload: PaycheckSignatureEventUpdate,
+): Promise<PaycheckSignatureEvent> => {
+  const response = await supabase
+    .from<PaycheckSignatureEvent>('paycheck_signature_events')
+    .update(payload)
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(eventId, 'eventId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to update paycheck signature event');
+};
+
+export const deletePaycheckSignatureEvent = async (
+  companyId: string,
+  eventId: string,
+): Promise<void> => {
+  const response = await supabase
+    .from('paycheck_signature_events')
+    .delete()
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(eventId, 'eventId'));
+
+  ensureNoError(response, 'Unable to delete paycheck signature event');
+};

--- a/lib/repositories/paychecksStorageRepository.ts
+++ b/lib/repositories/paychecksStorageRepository.ts
@@ -1,0 +1,132 @@
+import { uploadFile, createSignedUrl, removeFiles } from '@/lib/adapters/supabaseStorage';
+import { RepositoryError } from '@/lib/adapters/supabaseAdapter';
+import { ensureCompanyScope, ensureIdentifier } from '@/lib/middlewares/ensureCompanyScope';
+import {
+  getPaycheckById,
+  updatePaycheck,
+} from '@/lib/repositories/paychecksRepository';
+import type { Paycheck } from '@/types/db';
+import type { SignedUrlOptions, SignedUrlResult, StorageFile, StorageUploadOptions } from '@/types/storage';
+
+const sanitizeFileName = (fileName: string): string => fileName.trim().replace(/\s+/g, '-');
+
+const buildPaycheckFilePath = ({
+  companyId,
+  paycheckId,
+  fileName,
+}: {
+  companyId: string;
+  paycheckId: string;
+  fileName: string;
+}): string => `company/${companyId}/paychecks/${paycheckId}/${sanitizeFileName(fileName)}`;
+
+export interface UploadPaycheckFileParams {
+  companyId: string;
+  paycheckId: string;
+  file: StorageFile;
+  fileName: string;
+  contentType?: string;
+  storageOptions?: StorageUploadOptions;
+  metadata?: Record<string, unknown>;
+  fileSize?: number;
+  checksum?: string;
+  removePrevious?: boolean;
+}
+
+export const uploadPaycheckFile = async (
+  params: UploadPaycheckFileParams,
+): Promise<Paycheck> => {
+  const companyId = ensureCompanyScope(params.companyId);
+  const paycheckId = ensureIdentifier(params.paycheckId, 'paycheckId');
+  const existing = await getPaycheckById(companyId, paycheckId);
+  const path = buildPaycheckFilePath({
+    companyId,
+    paycheckId,
+    fileName: params.fileName,
+  });
+
+  await uploadFile('paychecks', path, params.file, {
+    cacheControl: params.storageOptions?.cacheControl,
+    contentType: params.contentType,
+    metadata: params.storageOptions?.metadata,
+    upsert: params.storageOptions?.upsert ?? false,
+  });
+
+  if (params.removePrevious !== false && existing.file_path && existing.file_path !== path) {
+    await removeFiles('paychecks', [existing.file_path]);
+  }
+
+  const baseMetadata =
+    typeof existing.metadata === 'object' && existing.metadata !== null
+      ? (existing.metadata as Record<string, unknown>)
+      : {};
+
+  const updatedMetadata: Record<string, unknown> = {
+    ...baseMetadata,
+    ...params.metadata,
+    lastUploadedAt: new Date().toISOString(),
+  };
+
+  if (params.contentType || baseMetadata.contentType) {
+    updatedMetadata.contentType = params.contentType ?? baseMetadata.contentType;
+  }
+
+  if (params.fileSize || baseMetadata.size) {
+    updatedMetadata.size = params.fileSize ?? baseMetadata.size;
+  }
+
+  if (params.checksum || baseMetadata.checksum) {
+    updatedMetadata.checksum = params.checksum ?? baseMetadata.checksum;
+  }
+
+  const updated = await updatePaycheck(companyId, paycheckId, {
+    file_path: path,
+    metadata: updatedMetadata,
+  });
+
+  return updated;
+};
+
+export const createPaycheckSignedUrl = async (
+  companyId: string,
+  paycheckId: string,
+  options: SignedUrlOptions,
+): Promise<SignedUrlResult> => {
+  const paycheck = await getPaycheckById(companyId, paycheckId);
+
+  if (!paycheck.file_path) {
+    throw new RepositoryError('Paycheck file not available', { status: 404 });
+  }
+
+  return createSignedUrl('paychecks', paycheck.file_path, options);
+};
+
+export const deletePaycheckFile = async (
+  companyId: string,
+  paycheckId: string,
+): Promise<Paycheck> => {
+  const existing = await getPaycheckById(companyId, paycheckId);
+
+  if (!existing.file_path) {
+    throw new RepositoryError('Paycheck file not available', { status: 404 });
+  }
+
+  await removeFiles('paychecks', [existing.file_path]);
+
+  const metadata: Record<string, unknown> =
+    typeof existing.metadata === 'object' && existing.metadata !== null
+      ? { ...(existing.metadata as Record<string, unknown>) }
+      : {};
+  // Remove file-specific metadata keys if present
+  delete metadata.contentType;
+  delete metadata.size;
+  delete metadata.checksum;
+  metadata.lastRemovedAt = new Date().toISOString();
+
+  const updated = await updatePaycheck(companyId, paycheckId, {
+    file_path: null,
+    metadata,
+  });
+
+  return updated;
+};

--- a/lib/repositories/userRepository.ts
+++ b/lib/repositories/userRepository.ts
@@ -1,0 +1,249 @@
+import { supabase } from '@/lib/supabase';
+import {
+  ensureMutation,
+  ensureNoError,
+  RepositoryError,
+  unwrapList,
+  unwrapMaybeSingle,
+} from '@/lib/adapters/supabaseAdapter';
+import { ensureCompanyScope, ensureIdentifier } from '@/lib/middlewares/ensureCompanyScope';
+import type {
+  EmployeeProfile,
+  EmployeeProfileInsert,
+  EmployeeProfileReplace,
+  EmployeeProfileUpdate,
+  UserPreference,
+  UserPreferenceInsert,
+  UserPreferenceReplace,
+  UserPreferenceUpdate,
+  UserProfile,
+  UserProfileInsert,
+  UserProfileReplace,
+  UserProfileUpdate,
+} from '@/types/db';
+
+export const getUserProfiles = async (): Promise<UserProfile[]> => {
+  const response = await supabase
+    .from<UserProfile>('user_profiles')
+    .select('*')
+    .order('created_at', { ascending: true });
+
+  return unwrapList(response, 'Unable to load user profiles');
+};
+
+export const getUserProfileById = async (userId: string): Promise<UserProfile> => {
+  const response = await supabase
+    .from<UserProfile>('user_profiles')
+    .select('*')
+    .eq('user_id', ensureIdentifier(userId, 'userId'))
+    .maybeSingle();
+
+  const profile = unwrapMaybeSingle(response, 'Unable to load user profile');
+
+  if (!profile) {
+    throw new RepositoryError('User profile not found', { status: 404 });
+  }
+
+  return profile;
+};
+
+export const createUserProfile = async (
+  payload: UserProfileInsert,
+): Promise<UserProfile> => {
+  const response = await supabase
+    .from<UserProfile>('user_profiles')
+    .insert(payload)
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to create user profile');
+};
+
+export const replaceUserProfile = async (
+  userId: string,
+  payload: UserProfileReplace,
+): Promise<UserProfile> => {
+  const response = await supabase
+    .from<UserProfile>('user_profiles')
+    .update(payload)
+    .eq('user_id', ensureIdentifier(userId, 'userId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to replace user profile');
+};
+
+export const updateUserProfile = async (
+  userId: string,
+  payload: UserProfileUpdate,
+): Promise<UserProfile> => {
+  const response = await supabase
+    .from<UserProfile>('user_profiles')
+    .update(payload)
+    .eq('user_id', ensureIdentifier(userId, 'userId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to update user profile');
+};
+
+export const deleteUserProfile = async (userId: string): Promise<void> => {
+  const response = await supabase
+    .from('user_profiles')
+    .delete()
+    .eq('user_id', ensureIdentifier(userId, 'userId'));
+
+  ensureNoError(response, 'Unable to delete user profile');
+};
+
+export const getEmployeeProfiles = async (
+  companyId: string,
+): Promise<EmployeeProfile[]> => {
+  const response = await supabase
+    .from<EmployeeProfile>('employee_profiles')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .order('created_at', { ascending: true });
+
+  return unwrapList(response, 'Unable to load employee profiles');
+};
+
+export const getEmployeeProfileById = async (
+  companyId: string,
+  employeeId: string,
+): Promise<EmployeeProfile> => {
+  const response = await supabase
+    .from<EmployeeProfile>('employee_profiles')
+    .select('*')
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(employeeId, 'employeeId'))
+    .maybeSingle();
+
+  const employee = unwrapMaybeSingle(response, 'Unable to load employee profile');
+
+  if (!employee) {
+    throw new RepositoryError('Employee profile not found', { status: 404 });
+  }
+
+  return employee;
+};
+
+export const createEmployeeProfile = async (
+  companyId: string,
+  payload: EmployeeProfileInsert,
+): Promise<EmployeeProfile> => {
+  const response = await supabase
+    .from<EmployeeProfile>('employee_profiles')
+    .insert({ ...payload, company_id: ensureCompanyScope(companyId) })
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to create employee profile');
+};
+
+export const replaceEmployeeProfile = async (
+  companyId: string,
+  employeeId: string,
+  payload: EmployeeProfileReplace,
+): Promise<EmployeeProfile> => {
+  const scopedCompanyId = ensureCompanyScope(companyId);
+  const response = await supabase
+    .from<EmployeeProfile>('employee_profiles')
+    .update({ ...payload, company_id: scopedCompanyId })
+    .eq('company_id', scopedCompanyId)
+    .eq('id', ensureIdentifier(employeeId, 'employeeId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to replace employee profile');
+};
+
+export const updateEmployeeProfile = async (
+  companyId: string,
+  employeeId: string,
+  payload: EmployeeProfileUpdate,
+): Promise<EmployeeProfile> => {
+  const response = await supabase
+    .from<EmployeeProfile>('employee_profiles')
+    .update(payload)
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(employeeId, 'employeeId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to update employee profile');
+};
+
+export const deleteEmployeeProfile = async (
+  companyId: string,
+  employeeId: string,
+): Promise<void> => {
+  const response = await supabase
+    .from('employee_profiles')
+    .delete()
+    .eq('company_id', ensureCompanyScope(companyId))
+    .eq('id', ensureIdentifier(employeeId, 'employeeId'));
+
+  ensureNoError(response, 'Unable to delete employee profile');
+};
+
+export const getUserPreferences = async (
+  userId: string,
+): Promise<UserPreference | null> => {
+  const response = await supabase
+    .from<UserPreference>('user_preferences')
+    .select('*')
+    .eq('user_id', ensureIdentifier(userId, 'userId'))
+    .maybeSingle();
+
+  return unwrapMaybeSingle(response, 'Unable to load user preferences');
+};
+
+export const createUserPreferences = async (
+  payload: UserPreferenceInsert,
+): Promise<UserPreference> => {
+  const response = await supabase
+    .from<UserPreference>('user_preferences')
+    .insert(payload)
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to create user preferences');
+};
+
+export const replaceUserPreferences = async (
+  userId: string,
+  payload: UserPreferenceReplace,
+): Promise<UserPreference> => {
+  const response = await supabase
+    .from<UserPreference>('user_preferences')
+    .update(payload)
+    .eq('user_id', ensureIdentifier(userId, 'userId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to replace user preferences');
+};
+
+export const updateUserPreferences = async (
+  userId: string,
+  payload: UserPreferenceUpdate,
+): Promise<UserPreference> => {
+  const response = await supabase
+    .from<UserPreference>('user_preferences')
+    .update(payload)
+    .eq('user_id', ensureIdentifier(userId, 'userId'))
+    .select('*')
+    .single();
+
+  return ensureMutation(response, 'Unable to update user preferences');
+};
+
+export const deleteUserPreferences = async (userId: string): Promise<void> => {
+  const response = await supabase
+    .from('user_preferences')
+    .delete()
+    .eq('user_id', ensureIdentifier(userId, 'userId'));
+
+  ensureNoError(response, 'Unable to delete user preferences');
+};

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,5 +1,34 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createClient } from '@supabase/supabase-js';
+
+type StorageAdapter = {
+  getItem: (key: string) => Promise<string | null>;
+  setItem: (key: string, value: string) => Promise<void>;
+  removeItem: (key: string) => Promise<void>;
+};
+
+const createMemoryStorage = (): StorageAdapter => {
+  const store = new Map<string, string>();
+  return {
+    async getItem(key) {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    async setItem(key, value) {
+      store.set(key, value);
+    },
+    async removeItem(key) {
+      store.delete(key);
+    },
+  };
+};
+
+let storage: StorageAdapter;
+
+if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+  storage = require('@react-native-async-storage/async-storage').default;
+} else {
+  storage = createMemoryStorage();
+}
 
 const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
@@ -14,7 +43,7 @@ if (!supabaseAnonKey) {
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {
-    storage: AsyncStorage,
+    storage,
     autoRefreshToken: true,
     persistSession: true,
     detectSessionInUrl: false,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "expo lint",
     "lint:fix": "expo lint -- --fix",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "db:setup": "node scripts/create-supabase-schema.mjs"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
@@ -61,6 +62,8 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
     "prettier": "^3.6.2",
+    "pg": "^8.13.1",
+    "dotenv": "^16.4.7",
     "tailwindcss": "3.4.14",
     "typescript": "~5.9.2"
   },

--- a/scripts/create-supabase-schema.mjs
+++ b/scripts/create-supabase-schema.mjs
@@ -1,0 +1,328 @@
+import 'dotenv/config';
+import pg from 'pg';
+
+const { Client } = pg;
+
+const connectionString =
+  process.env.SUPABASE_DB_URL ??
+  process.env.SUPABASE_DB_CONNECTION_STRING ??
+  process.env.EXPO_PUBLIC_SUPABASE_URL_DB ??
+  process.env.EXPO_PUBLIC_SUPABASE_URL_SQL ??
+  process.env.DATABASE_URL ??
+  null;
+
+if (!connectionString) {
+  console.error(
+    'Missing database connection string. Set SUPABASE_DB_URL (or EXPO_PUBLIC_SUPABASE_URL_DB) using the Supabase Settings → Database → Connection string.',
+  );
+  process.exit(1);
+}
+
+const statements = [
+  `create extension if not exists "pgcrypto";`,
+  `create table if not exists public.companies (
+    id uuid primary key default gen_random_uuid(),
+    name text not null,
+    legal_name text,
+    company_code text not null unique,
+    country_code text not null,
+    default_time_zone text not null default 'UTC',
+    plan_tier text not null default 'trial',
+    plan_renewal_at timestamptz,
+    billing_email text,
+    industry text,
+    employee_count_estimate integer,
+    logo_url text,
+    created_by uuid references auth.users(id),
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deactivated_at timestamptz,
+    metadata jsonb not null default '{}'::jsonb,
+    constraint companies_plan_tier_check check (plan_tier in ('trial','starter','growth','enterprise'))
+  );`,
+  `create index if not exists idx_companies_plan_tier on public.companies(plan_tier);`,
+  `create index if not exists idx_companies_country on public.companies(country_code);`,
+  `create table if not exists public.user_profiles (
+    user_id uuid primary key references auth.users(id) on delete cascade,
+    full_name text not null,
+    preferred_name text,
+    avatar_url text,
+    phone text,
+    time_zone text not null default 'UTC',
+    locale text not null default 'en',
+    bio text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+  );`,
+  `create index if not exists idx_user_profiles_locale on public.user_profiles(locale);`,
+  `create index if not exists idx_user_profiles_time_zone on public.user_profiles(time_zone);`,
+  `create table if not exists public.company_members (
+    id uuid primary key default gen_random_uuid(),
+    company_id uuid not null references public.companies(id) on delete cascade,
+    user_id uuid not null references auth.users(id) on delete cascade,
+    role text not null,
+    status text not null default 'invited',
+    invited_at timestamptz not null default now(),
+    joined_at timestamptz,
+    suspended_at timestamptz,
+    invited_by uuid references auth.users(id),
+    note text,
+    created_at timestamptz not null default now(),
+    constraint company_members_role_check check (role in ('admin','employee')),
+    constraint company_members_status_check check (status in ('invited','active','suspended','left')),
+    constraint company_members_unique unique (company_id, user_id)
+  );`,
+  `create index if not exists idx_company_members_company_role on public.company_members(company_id, role);`,
+  `create index if not exists idx_company_members_status on public.company_members(company_id, status);`,
+  `create table if not exists public.employee_profiles (
+    id uuid primary key default gen_random_uuid(),
+    company_id uuid not null references public.companies(id) on delete cascade,
+    member_id uuid not null references public.company_members(id) on delete cascade,
+    employee_number text,
+    job_title text,
+    department text,
+    manager_member_id uuid references public.company_members(id) on delete set null,
+    birthday date,
+    hire_date date,
+    termination_date date,
+    is_active boolean not null default true,
+    pin_hash text,
+    pin_failed_attempts smallint not null default 0,
+    pin_locked_until timestamptz,
+    pin_last_reset_at timestamptz,
+    emergency_contact jsonb,
+    address jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint employee_profiles_unique_number unique (company_id, employee_number)
+  );`,
+  `create index if not exists idx_employee_profiles_company_manager on public.employee_profiles(company_id, manager_member_id);`,
+  `create index if not exists idx_employee_profiles_active on public.employee_profiles(company_id, is_active);`,
+  `create table if not exists public.user_preferences (
+    user_id uuid primary key references auth.users(id) on delete cascade,
+    company_id uuid references public.companies(id) on delete set null,
+    theme text not null default 'system',
+    language text not null default 'en',
+    timezone_override text,
+    receive_company_announcements boolean not null default true,
+    receive_payroll_notifications boolean not null default true,
+    receive_document_prompts boolean not null default true,
+    biometric_auth_enabled boolean not null default false,
+    pin_required_for_sensitive boolean not null default true,
+    marketing_opt_in boolean not null default false,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    updated_by uuid references auth.users(id),
+    constraint user_preferences_theme_check check (theme in ('system','light','dark'))
+  );`,
+  `create index if not exists idx_user_preferences_company on public.user_preferences(company_id);`,
+  `create table if not exists public.audit_logs (
+    id uuid primary key default gen_random_uuid(),
+    company_id uuid not null references public.companies(id) on delete cascade,
+    actor_id uuid references auth.users(id),
+    action text not null,
+    severity text not null default 'info',
+    metadata jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    constraint audit_logs_severity_check check (severity in ('info','warning','critical'))
+  );`,
+  `create index if not exists idx_audit_logs_company_time on public.audit_logs(company_id, created_at desc);`,
+  `create table if not exists public.document_categories (
+    id uuid primary key default gen_random_uuid(),
+    company_id uuid not null references public.companies(id) on delete cascade,
+    name text not null,
+    description text,
+    is_active boolean not null default true,
+    created_by uuid references auth.users(id),
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint document_categories_unique_name unique (company_id, name)
+  );`,
+  `create index if not exists idx_document_categories_active on public.document_categories(company_id, is_active);`,
+  `create table if not exists public.document_templates (
+    id uuid primary key default gen_random_uuid(),
+    company_id uuid not null references public.companies(id) on delete cascade,
+    category_id uuid references public.document_categories(id) on delete set null,
+    title text not null,
+    description text,
+    requires_signature boolean not null default true,
+    is_published boolean not null default false,
+    valid_from date,
+    valid_until date,
+    default_due_days integer,
+    version integer not null default 1,
+    last_published_at timestamptz,
+    created_by uuid references auth.users(id),
+    updated_by uuid references auth.users(id),
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+  );`,
+  `create index if not exists idx_document_templates_company_status on public.document_templates(company_id, is_published);`,
+  `create index if not exists idx_document_templates_category on public.document_templates(category_id);`,
+  `create table if not exists public.documents (
+    id uuid primary key default gen_random_uuid(),
+    company_id uuid not null references public.companies(id) on delete cascade,
+    template_id uuid references public.document_templates(id),
+    employee_id uuid not null references public.employee_profiles(id) on delete cascade,
+    title text not null,
+    status text not null default 'pending',
+    issued_at timestamptz not null default now(),
+    due_at timestamptz,
+    signed_at timestamptz,
+    signed_by uuid references auth.users(id),
+    rejected_at timestamptz,
+    rejected_reason text,
+    expired_at timestamptz,
+    metadata jsonb not null default '{}'::jsonb,
+    created_by uuid references auth.users(id),
+    updated_at timestamptz not null default now(),
+    constraint documents_status_check check (status in ('pending','signed','rejected','expired'))
+  );`,
+  `create index if not exists idx_documents_employee_status on public.documents(employee_id, status);`,
+  `create index if not exists idx_documents_company_due on public.documents(company_id, due_at);`,
+  `create table if not exists public.document_files (
+    id uuid primary key default gen_random_uuid(),
+    company_id uuid not null references public.companies(id) on delete cascade,
+    document_id uuid references public.documents(id) on delete cascade,
+    template_id uuid references public.document_templates(id) on delete cascade,
+    file_path text not null,
+    file_size integer,
+    content_type text,
+    version integer not null default 1,
+    uploaded_by uuid references auth.users(id),
+    uploaded_at timestamptz not null default now(),
+    checksum text
+  );`,
+  `create index if not exists idx_document_files_document_version on public.document_files(document_id, version desc);`,
+  `create index if not exists idx_document_files_template on public.document_files(template_id);`,
+  `create table if not exists public.notification_channels (
+    id uuid primary key default gen_random_uuid(),
+    company_id uuid references public.companies(id) on delete cascade,
+    user_id uuid not null references auth.users(id) on delete cascade,
+    type text not null,
+    target text not null,
+    is_verified boolean not null default false,
+    verification_code text,
+    verification_expires_at timestamptz,
+    last_seen_at timestamptz,
+    device_info jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint notification_channels_type_check check (type in ('push','email')),
+    constraint notification_channels_unique_target unique (type, target)
+  );`,
+  `create index if not exists idx_notification_channels_user_type on public.notification_channels(user_id, type);`,
+  `create table if not exists public.notifications (
+    id uuid primary key default gen_random_uuid(),
+    company_id uuid references public.companies(id) on delete cascade,
+    category text not null,
+    title text not null,
+    body text,
+    payload jsonb not null default '{}'::jsonb,
+    priority text not null default 'normal',
+    target_scope text not null default 'user',
+    target_user_id uuid references auth.users(id) on delete cascade,
+    target_employee_id uuid references public.employee_profiles(id) on delete cascade,
+    source_reference text,
+    scheduled_at timestamptz,
+    created_by uuid references auth.users(id),
+    created_at timestamptz not null default now(),
+    constraint notifications_priority_check check (priority in ('low','normal','high')),
+    constraint notifications_scope_check check (target_scope in ('user','company','custom'))
+  );`,
+  `create index if not exists idx_notifications_company_created on public.notifications(company_id, created_at desc);`,
+  `create index if not exists idx_notifications_target_user on public.notifications(target_user_id) where target_scope = 'user';`,
+  `create table if not exists public.notification_deliveries (
+    id uuid primary key default gen_random_uuid(),
+    notification_id uuid not null references public.notifications(id) on delete cascade,
+    channel_id uuid not null references public.notification_channels(id) on delete cascade,
+    status text not null default 'pending',
+    sent_at timestamptz,
+    read_at timestamptz,
+    fail_reason text,
+    retry_count integer not null default 0,
+    metadata jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    constraint notification_deliveries_status_check check (status in ('pending','sent','failed','read'))
+  );`,
+  `create index if not exists idx_notification_deliveries_notification on public.notification_deliveries(notification_id);`,
+  `create index if not exists idx_notification_deliveries_failed on public.notification_deliveries(status) where status = 'failed';`,
+  `create table if not exists public.events (
+    id uuid primary key default gen_random_uuid(),
+    company_id uuid not null references public.companies(id) on delete cascade,
+    type text not null,
+    title text not null,
+    description text,
+    start_at timestamptz not null,
+    end_at timestamptz,
+    is_all_day boolean not null default false,
+    source text not null default 'manual',
+    location text,
+    created_by uuid references auth.users(id),
+    updated_by uuid references auth.users(id),
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    cancelled_at timestamptz,
+    metadata jsonb not null default '{}'::jsonb,
+    constraint events_type_check check (type in ('company','birthday','holiday','hr_event')),
+    constraint events_source_check check (source in ('manual','generated','imported'))
+  );`,
+  `create index if not exists idx_events_company_start on public.events(company_id, start_at);`,
+  `create index if not exists idx_events_type on public.events(company_id, type);`,
+  `create table if not exists public.event_attendees (
+    id uuid primary key default gen_random_uuid(),
+    event_id uuid not null references public.events(id) on delete cascade,
+    employee_id uuid not null references public.employee_profiles(id) on delete cascade,
+    response_status text not null default 'pending',
+    notified_at timestamptz,
+    response_at timestamptz,
+    metadata jsonb not null default '{}'::jsonb,
+    constraint event_attendees_status_check check (response_status in ('pending','accepted','declined')),
+    constraint event_attendees_unique unique (event_id, employee_id)
+  );`,
+  `create index if not exists idx_event_attendees_employee on public.event_attendees(employee_id);`,
+  `create table if not exists public.holiday_calendars (
+    id uuid primary key default gen_random_uuid(),
+    company_id uuid not null references public.companies(id) on delete cascade,
+    country_code text not null,
+    name text not null,
+    date date not null,
+    source text not null,
+    is_observed boolean not null default true,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+  );`,
+  `create index if not exists idx_holiday_calendars_company_date on public.holiday_calendars(company_id, date);`,
+  `create index if not exists idx_holiday_calendars_country on public.holiday_calendars(country_code, date);`,
+];
+
+async function run() {
+  const client = new Client({ connectionString, ssl: { rejectUnauthorized: false } });
+
+  try {
+    await client.connect();
+
+    for (const statement of statements) {
+      const preview = statement.split('\n')[0].slice(0, 80);
+      console.log(`\n➡️  ${preview}...`);
+      try {
+        await client.query(statement);
+      } catch (error) {
+        console.error('❌ Error executing statement:', error.message ?? error);
+        if (error.position) {
+          console.error('Position:', error.position);
+        }
+        throw error;
+      }
+    }
+
+    console.log('\n✅ Schema creation statements executed successfully.');
+  } catch (error) {
+    console.error('Schema setup failed.', error);
+    process.exitCode = 1;
+  } finally {
+    await client.end();
+  }
+}
+
+run();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "strict": true,
     "jsxImportSource": "nativewind",
+    "jsx": "react",
     "paths": {
       "@/*": ["./*"]
     }

--- a/types/db.ts
+++ b/types/db.ts
@@ -1,0 +1,396 @@
+export type PlanTier = 'trial' | 'starter' | 'growth' | 'enterprise';
+
+export interface Company {
+  id: string;
+  name: string;
+  legal_name: string | null;
+  company_code: string;
+  country_code: string;
+  default_time_zone: string;
+  plan_tier: PlanTier;
+  plan_renewal_at: string | null;
+  billing_email: string | null;
+  industry: string | null;
+  employee_count_estimate: number | null;
+  logo_url: string | null;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+  deactivated_at: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+export type CompanyInsert = Omit<Company, 'id' | 'created_at' | 'updated_at'> & {
+  id?: string;
+};
+
+export type CompanyReplace = CompanyInsert;
+
+export type CompanyUpdate = Partial<CompanyInsert>;
+
+export type MemberRole = 'admin' | 'employee';
+
+export type MemberStatus = 'invited' | 'active' | 'suspended' | 'left';
+
+export interface CompanyMember {
+  id: string;
+  company_id: string;
+  user_id: string;
+  role: MemberRole;
+  status: MemberStatus;
+  invited_at: string;
+  joined_at: string | null;
+  suspended_at: string | null;
+  invited_by: string | null;
+  note: string | null;
+  created_at: string;
+}
+
+export type CompanyMemberInsert = Omit<CompanyMember, 'id' | 'created_at'> & {
+  id?: string;
+};
+
+export type CompanyMemberReplace = CompanyMemberInsert;
+
+export type CompanyMemberUpdate = Partial<CompanyMemberInsert>;
+
+export type AuditSeverity = 'info' | 'warning' | 'error' | 'critical';
+
+export interface AuditLog {
+  id: string;
+  company_id: string;
+  actor_id: string | null;
+  action: string;
+  severity: AuditSeverity;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export type AuditLogInsert = Omit<AuditLog, 'id' | 'created_at'> & {
+  id?: string;
+};
+
+export type AuditLogReplace = AuditLogInsert;
+
+export type AuditLogUpdate = Partial<AuditLogInsert>;
+
+export interface UserProfile {
+  user_id: string;
+  full_name: string;
+  preferred_name: string | null;
+  avatar_url: string | null;
+  phone: string | null;
+  time_zone: string;
+  locale: string;
+  bio: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type UserProfileInsert = Omit<UserProfile, 'created_at' | 'updated_at'>;
+
+export type UserProfileReplace = UserProfileInsert;
+
+export type UserProfileUpdate = Partial<UserProfileInsert>;
+
+export interface EmployeeProfile {
+  id: string;
+  company_id: string;
+  member_id: string;
+  employee_number: string | null;
+  job_title: string | null;
+  department: string | null;
+  manager_member_id: string | null;
+  birthday: string | null;
+  hire_date: string | null;
+  termination_date: string | null;
+  is_active: boolean;
+  pin_hash: string | null;
+  pin_failed_attempts: number;
+  pin_locked_until: string | null;
+  pin_last_reset_at: string | null;
+  emergency_contact: Record<string, unknown> | null;
+  address: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type EmployeeProfileInsert = Omit<EmployeeProfile, 'id' | 'created_at' | 'updated_at'> & {
+  id?: string;
+};
+
+export type EmployeeProfileReplace = EmployeeProfileInsert;
+
+export type EmployeeProfileUpdate = Partial<EmployeeProfileInsert>;
+
+export type ThemePreference = 'system' | 'light' | 'dark';
+
+export interface UserPreference {
+  user_id: string;
+  company_id: string | null;
+  theme: ThemePreference;
+  language: string;
+  timezone_override: string | null;
+  receive_company_announcements: boolean;
+  receive_payroll_notifications: boolean;
+  receive_document_prompts: boolean;
+  biometric_auth_enabled: boolean;
+  pin_required_for_sensitive: boolean;
+  marketing_opt_in: boolean;
+  created_at: string;
+  updated_at: string;
+  updated_by: string | null;
+}
+
+export type UserPreferenceInsert = Omit<UserPreference, 'created_at' | 'updated_at'>;
+
+export type UserPreferenceReplace = UserPreferenceInsert;
+
+export type UserPreferenceUpdate = Partial<UserPreferenceInsert>;
+
+export interface DocumentCategory {
+  id: string;
+  company_id: string;
+  name: string;
+  description: string | null;
+  is_active: boolean;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type DocumentCategoryInsert = Omit<DocumentCategory, 'id' | 'created_at' | 'updated_at'> & {
+  id?: string;
+};
+
+export type DocumentCategoryReplace = DocumentCategoryInsert;
+
+export type DocumentCategoryUpdate = Partial<DocumentCategoryInsert>;
+
+export interface DocumentTemplate {
+  id: string;
+  company_id: string;
+  category_id: string | null;
+  title: string;
+  description: string | null;
+  requires_signature: boolean;
+  is_published: boolean;
+  valid_from: string | null;
+  valid_until: string | null;
+  default_due_days: number | null;
+  version: number;
+  last_published_at: string | null;
+  created_by: string | null;
+  updated_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type DocumentTemplateInsert = Omit<DocumentTemplate, 'id' | 'version' | 'created_at' | 'updated_at'> & {
+  id?: string;
+  version?: number;
+};
+
+export type DocumentTemplateReplace = DocumentTemplateInsert;
+
+export type DocumentTemplateUpdate = Partial<DocumentTemplateInsert>;
+
+export type DocumentStatus = 'pending' | 'signed' | 'rejected' | 'expired';
+
+export interface Document {
+  id: string;
+  company_id: string;
+  template_id: string | null;
+  employee_id: string;
+  title: string;
+  status: DocumentStatus;
+  issued_at: string;
+  due_at: string | null;
+  signed_at: string | null;
+  signed_by: string | null;
+  rejected_at: string | null;
+  rejected_reason: string | null;
+  expired_at: string | null;
+  metadata: Record<string, unknown> | null;
+  created_by: string | null;
+  updated_at: string;
+}
+
+export type DocumentInsert = Omit<Document, 'id' | 'updated_at'> & {
+  id?: string;
+};
+
+export type DocumentReplace = DocumentInsert;
+
+export type DocumentUpdate = Partial<DocumentInsert>;
+
+export interface DocumentFile {
+  id: string;
+  company_id: string;
+  document_id: string | null;
+  template_id: string | null;
+  file_path: string;
+  file_size: number | null;
+  content_type: string | null;
+  version: number;
+  uploaded_by: string | null;
+  uploaded_at: string;
+  checksum: string | null;
+}
+
+export type DocumentFileInsert = Omit<DocumentFile, 'id' | 'uploaded_at' | 'version'> & {
+  id?: string;
+  version?: number;
+};
+
+export type DocumentFileReplace = DocumentFileInsert;
+
+export type DocumentFileUpdate = Partial<DocumentFileInsert>;
+
+export type EventType = 'company' | 'birthday' | 'holiday' | 'hr_event';
+
+export type EventSource = 'manual' | 'generated' | 'imported';
+
+export interface EventRecord {
+  id: string;
+  company_id: string;
+  type: EventType;
+  title: string;
+  description: string | null;
+  start_at: string;
+  end_at: string | null;
+  is_all_day: boolean;
+  source: EventSource;
+  location: string | null;
+  created_by: string | null;
+  updated_by: string | null;
+  created_at: string;
+  updated_at: string;
+  cancelled_at: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+export type EventInsert = Omit<EventRecord, 'id' | 'created_at' | 'updated_at'> & {
+  id?: string;
+};
+
+export type EventReplace = EventInsert;
+
+export type EventUpdate = Partial<EventInsert>;
+
+export type AttendanceStatus = 'pending' | 'accepted' | 'declined';
+
+export interface EventAttendee {
+  id: string;
+  event_id: string;
+  employee_id: string;
+  response_status: AttendanceStatus;
+  notified_at: string | null;
+  response_at: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+export type EventAttendeeInsert = Omit<EventAttendee, 'id'> & {
+  id?: string;
+};
+
+export type EventAttendeeReplace = EventAttendeeInsert;
+
+export type EventAttendeeUpdate = Partial<EventAttendeeInsert>;
+
+export interface HolidayCalendar {
+  id: string;
+  company_id: string;
+  country_code: string;
+  name: string;
+  date: string;
+  source: string;
+  is_observed: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export type HolidayCalendarInsert = Omit<HolidayCalendar, 'id' | 'created_at' | 'updated_at'> & {
+  id?: string;
+};
+
+export type HolidayCalendarReplace = HolidayCalendarInsert;
+
+export type HolidayCalendarUpdate = Partial<HolidayCalendarInsert>;
+
+export type NotificationChannelType = 'push' | 'email';
+
+export interface NotificationChannel {
+  id: string;
+  company_id: string | null;
+  user_id: string;
+  type: NotificationChannelType;
+  target: string;
+  is_verified: boolean;
+  verification_code: string | null;
+  verification_expires_at: string | null;
+  last_seen_at: string | null;
+  device_info: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type NotificationChannelInsert = Omit<NotificationChannel, 'id' | 'created_at' | 'updated_at'> & {
+  id?: string;
+};
+
+export type NotificationChannelReplace = NotificationChannelInsert;
+
+export type NotificationChannelUpdate = Partial<NotificationChannelInsert>;
+
+export type NotificationPriority = 'low' | 'normal' | 'high';
+
+export type NotificationScope = 'user' | 'company' | 'custom';
+
+export interface NotificationRecord {
+  id: string;
+  company_id: string | null;
+  category: string;
+  title: string;
+  body: string | null;
+  payload: Record<string, unknown> | null;
+  priority: NotificationPriority;
+  target_scope: NotificationScope;
+  target_user_id: string | null;
+  target_employee_id: string | null;
+  source_reference: string | null;
+  scheduled_at: string | null;
+  created_by: string | null;
+  created_at: string;
+}
+
+export type NotificationInsert = Omit<NotificationRecord, 'id' | 'created_at'> & {
+  id?: string;
+};
+
+export type NotificationReplace = NotificationInsert;
+
+export type NotificationUpdate = Partial<NotificationInsert>;
+
+export type DeliveryStatus = 'pending' | 'sent' | 'failed' | 'read';
+
+export interface NotificationDelivery {
+  id: string;
+  notification_id: string;
+  channel_id: string;
+  status: DeliveryStatus;
+  sent_at: string | null;
+  read_at: string | null;
+  fail_reason: string | null;
+  retry_count: number;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export type NotificationDeliveryInsert = Omit<NotificationDelivery, 'id' | 'created_at'> & {
+  id?: string;
+};
+
+export type NotificationDeliveryReplace = NotificationDeliveryInsert;
+
+export type NotificationDeliveryUpdate = Partial<NotificationDeliveryInsert>;

--- a/types/db.ts
+++ b/types/db.ts
@@ -394,3 +394,55 @@ export type NotificationDeliveryInsert = Omit<NotificationDelivery, 'id' | 'crea
 export type NotificationDeliveryReplace = NotificationDeliveryInsert;
 
 export type NotificationDeliveryUpdate = Partial<NotificationDeliveryInsert>;
+
+export type PaycheckStatus = 'unsigned' | 'signed';
+
+export interface Paycheck {
+  id: string;
+  company_id: string;
+  employee_id: string;
+  period_start: string;
+  period_end: string;
+  gross_amount: number;
+  net_amount: number;
+  currency: string;
+  file_path: string | null;
+  issued_at: string;
+  status: PaycheckStatus;
+  viewed_at: string | null;
+  downloaded_at: string | null;
+  signed_at: string | null;
+  signed_by: string | null;
+  created_at: string;
+  updated_at: string;
+  metadata: Record<string, unknown> | null;
+}
+
+export type PaycheckInsert = Omit<Paycheck, 'id' | 'created_at' | 'updated_at' | 'status'> & {
+  id?: string;
+  status?: PaycheckStatus;
+};
+
+export type PaycheckReplace = PaycheckInsert;
+
+export type PaycheckUpdate = Partial<PaycheckInsert>;
+
+export type PaycheckSignatureEventType = 'pin_entered' | 'biometric_success' | 'biometric_failure';
+
+export interface PaycheckSignatureEvent {
+  id: string;
+  company_id: string;
+  paycheck_id: string;
+  employee_id: string;
+  event_type: PaycheckSignatureEventType;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export type PaycheckSignatureEventInsert = Omit<PaycheckSignatureEvent, 'id' | 'created_at'> & {
+  id?: string;
+};
+
+export type PaycheckSignatureEventReplace = PaycheckSignatureEventInsert;
+
+export type PaycheckSignatureEventUpdate = Partial<PaycheckSignatureEventInsert>;

--- a/types/hooks/auth.ts
+++ b/types/hooks/auth.ts
@@ -8,6 +8,7 @@ export type AuthUser = {
   cuil?: string | null;
   companyName?: string | null;
   companyDescription?: string | null;
+  companyCode?: string | null;
 };
 
 export type CredentialsPayload = {
@@ -19,6 +20,13 @@ export type RegisterPayload = {
   email: string;
   password: string;
   fullName?: string;
+  companyCode: string;
+  companyName?: string;
+  countryCode?: string;
+  defaultTimeZone?: string;
+  industry?: string;
+  billingEmail?: string;
+  companyDescription?: string;
 };
 
 export type PasswordResetPayload = {

--- a/types/screens/auth.ts
+++ b/types/screens/auth.ts
@@ -12,4 +12,11 @@ export type SignUpFormValues = {
   email: string;
   password: string;
   confirmPassword: string;
+  companyCode: string;
+  companyName?: string;
+  countryCode?: string;
+  defaultTimeZone?: string;
+  industry?: string;
+  billingEmail?: string;
+  companyDescription?: string;
 };

--- a/types/screens/documents.ts
+++ b/types/screens/documents.ts
@@ -1,5 +1,7 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
+import type { DocumentStatus } from '@/types/db';
+
 export const DOCUMENT_TYPE_KEYS = ['legajo', 'recibos-anteriores', 'licencias', 'sanciones', 'otros'] as const;
 export type DocumentTypeKey = (typeof DOCUMENT_TYPE_KEYS)[number];
 
@@ -11,53 +13,60 @@ export const DOCUMENT_TYPE_LABELS: Record<DocumentTypeKey, string> = {
   otros: 'Otros',
 };
 
+export const DOCUMENT_TYPE_ICONS: Record<DocumentTypeKey, React.ComponentProps<typeof MaterialIcons>['name']> = {
+  legajo: 'folder',
+  'recibos-anteriores': 'receipt-long',
+  licencias: 'medical-services',
+  sanciones: 'gavel',
+  otros: 'insert-drive-file',
+};
+
 export const DOCUMENT_TYPES = DOCUMENT_TYPE_KEYS.map((key) => ({
   key,
   label: DOCUMENT_TYPE_LABELS[key],
+  icon: DOCUMENT_TYPE_ICONS[key],
 }));
+
+export const DEFAULT_DOCUMENT_TYPE: DocumentTypeKey = 'otros';
+
+export const normalizeDocumentTypeKey = (value?: string | null): DocumentTypeKey => {
+  if (!value) {
+    return DEFAULT_DOCUMENT_TYPE;
+  }
+
+  return DOCUMENT_TYPE_KEYS.includes(value as DocumentTypeKey)
+    ? (value as DocumentTypeKey)
+    : DEFAULT_DOCUMENT_TYPE;
+};
 
 export type DocumentRecord = {
   id: string;
   title: string;
-  status: 'signed' | 'pending';
-  category?: string;
-  uri?: string;
+  status: DocumentStatus;
+  categoryKey: DocumentTypeKey;
+  categoryLabel: string;
+  notes?: string | null;
+  fileId: string | null;
+  filePath: string | null;
+  fileVersion: number | null;
+  contentType: string | null;
+  uploadedAt: string | null;
 };
 
-type DocumentGroup = {
+export type DocumentGroup = {
+  key: DocumentTypeKey;
+  label: string;
   icon: React.ComponentProps<typeof MaterialIcons>['name'];
   documents: DocumentRecord[];
 };
 
-export const documentMockData: Record<DocumentTypeKey, DocumentGroup> = {
-  legajo: {
-    icon: 'folder',
+export const createEmptyDocumentGroups = (): DocumentGroup[] =>
+  DOCUMENT_TYPES.map(({ key, label, icon }) => ({
+    key,
+    label,
+    icon,
     documents: [],
-  },
-  'recibos-anteriores': {
-    icon: 'receipt-long',
-    documents: [],
-  },
-  licencias: {
-    icon: 'medical-services',
-    documents: [
-      {
-        id: 'licencia-2024',
-        title: 'Lic. 2024 - Santi Bancalari.pdf',
-        status: 'signed',
-        category: 'Vacaciones',
-      },
-    ],
-  },
-  sanciones: {
-    icon: 'gavel',
-    documents: [],
-  },
-  otros: {
-    icon: 'insert-drive-file',
-    documents: [],
-  },
-};
+  }));
 
 export type SelectedFile = {
   uri: string;

--- a/types/screens/paychecks.ts
+++ b/types/screens/paychecks.ts
@@ -1,10 +1,15 @@
-export type PaycheckStatus = 'signed' | 'pending';
+import type { PaycheckStatus } from '@/types/db';
 
 export type PaycheckEntry = {
   id: string;
-  month: string;
+  issuedAt: string;
+  label: string;
   description: string;
   status: PaycheckStatus;
+  grossAmount?: number | null;
+  netAmount?: number | null;
+  currency?: string | null;
+  filePath?: string | null;
 };
 
 export type PaycheckGroup = {

--- a/types/screens/settings.ts
+++ b/types/screens/settings.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+
+export const profileFormSchema = z.object({
+  fullName: z
+    .string()
+    .transform((value) => value.trim())
+    .refine((value) => value.length > 0, 'Ingresa tu nombre completo'),
+  preferredName: z
+    .string()
+    .optional()
+    .transform((value) => (value?.trim() ? value.trim() : undefined)),
+  phone: z
+    .string()
+    .optional()
+    .transform((value) => (value?.trim() ? value.trim() : undefined)),
+  timeZone: z
+    .string()
+    .min(2, 'Ingresa un huso horario válido (ej: America/Argentina/Buenos_Aires)'),
+  locale: z
+    .string()
+    .min(2, 'Ingresa un código de idioma válido (ej: es-AR)'),
+  bio: z
+    .string()
+    .optional()
+    .transform((value) => (value?.trim() ? value.trim() : undefined)),
+  cuil: z
+    .string()
+    .optional()
+    .transform((value) => {
+      const trimmed = value?.replace(/[^0-9]/g, '') ?? '';
+      return trimmed.length > 0 ? trimmed : undefined;
+    }),
+});
+
+export type ProfileFormValues = z.infer<typeof profileFormSchema>;
+
+export const companyFormSchema = z.object({
+  companyCode: z
+    .string()
+    .transform((value) => value.trim())
+    .refine((value) => value.length >= 4, 'La clave debe tener al menos 4 caracteres'),
+  companyName: z
+    .string()
+    .optional()
+    .transform((value) => (value?.trim() ? value.trim() : undefined)),
+  countryCode: z
+    .string()
+    .optional()
+    .transform((value) => (value?.trim() ? value.trim().toUpperCase() : undefined)),
+  defaultTimeZone: z
+    .string()
+    .optional()
+    .transform((value) => (value?.trim() ? value.trim() : undefined)),
+  industry: z
+    .string()
+    .optional()
+    .transform((value) => (value?.trim() ? value.trim() : undefined)),
+  billingEmail: z
+    .string()
+    .optional()
+    .transform((value) => {
+      const trimmed = value?.trim();
+      return trimmed && trimmed.length > 0 ? trimmed : undefined;
+    }),
+  description: z
+    .string()
+    .optional()
+    .transform((value) => (value?.trim() ? value.trim() : undefined)),
+});
+
+export type CompanyFormValues = z.infer<typeof companyFormSchema>;

--- a/types/storage.ts
+++ b/types/storage.ts
@@ -1,0 +1,53 @@
+export type StorageBucket = 'documents' | 'paychecks' | 'avatars';
+
+export type StorageFile =
+  | Blob
+  | File
+  | ArrayBuffer
+  | Uint8Array
+  | Int8Array
+  | Uint16Array
+  | Int16Array
+  | Uint32Array
+  | Int32Array
+  | Float32Array
+  | Float64Array
+  | DataView;
+
+export interface StorageUploadOptions {
+  cacheControl?: string;
+  contentType?: string;
+  metadata?: Record<string, string>;
+  upsert?: boolean;
+}
+
+export interface StorageUploadResult {
+  path: string;
+  fullPath: string;
+  bucket: StorageBucket;
+}
+
+export interface SignedUrlOptions {
+  download?: boolean;
+  fileName?: string;
+  expiresIn: number;
+  transform?: {
+    width?: number;
+    height?: number;
+    resize?: 'cover' | 'contain' | 'fill';
+    quality?: number;
+    format?: 'origin' | 'webp' | 'png' | 'jpg';
+  };
+}
+
+export interface SignedUrlResult {
+  signedUrl: string;
+  path: string;
+  bucket: StorageBucket;
+  expiresAt: number;
+}
+
+export interface StorageRemoveResult {
+  path: string;
+  bucket: StorageBucket;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4366,7 +4366,7 @@ dotenv-expand@~11.0.6:
   dependencies:
     dotenv "^16.4.5"
 
-dotenv@^16.4.5:
+dotenv@^16.4.5, dotenv@^16.4.7:
   version "16.6.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.6.1.tgz#773f0e69527a8315c7285d5ee73c4459d20a8020"
   integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
@@ -6927,6 +6927,62 @@ path-scurry@^1.11.1, path-scurry@^1.6.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
+pg-cloudflare@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz#a1f3d226bab2c45ae75ea54d65ec05ac6cfafbef"
+  integrity sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==
+
+pg-connection-string@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.9.1.tgz#bb1fd0011e2eb76ac17360dc8fa183b2d3465238"
+  integrity sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==
+
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-pool@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.10.1.tgz#481047c720be2d624792100cac1816f8850d31b2"
+  integrity sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==
+
+pg-protocol@^1.10.3:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.10.3.tgz#ac9e4778ad3f84d0c5670583bab976ea0a34f69f"
+  integrity sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==
+
+pg-types@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.4"
+    postgres-interval "^1.1.0"
+
+pg@^8.13.1:
+  version "8.16.3"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.16.3.tgz#160741d0b44fdf64680e45374b06d632e86c99fd"
+  integrity sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==
+  dependencies:
+    pg-connection-string "^2.9.1"
+    pg-pool "^3.10.1"
+    pg-protocol "^1.10.3"
+    pg-types "2.2.0"
+    pgpass "1.0.5"
+  optionalDependencies:
+    pg-cloudflare "^1.2.7"
+
+pgpass@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.5.tgz#9b873e4a564bb10fa7a7dbd55312728d422a223d"
+  integrity sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==
+  dependencies:
+    split2 "^4.1.0"
+
 picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -7044,6 +7100,28 @@ postcss@~8.4.32:
     nanoid "^3.3.7"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
+
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.0.tgz#027b533c0aa890e26d172d47cf9ccecc521acd35"
+  integrity sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==
+
+postgres-date@~1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
+  integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
+
+postgres-interval@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+  dependencies:
+    xtend "^4.0.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -7886,6 +7964,11 @@ split-on-first@^1.0.0:
   resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
   integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
 
+split2@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
+  integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -8714,6 +8797,11 @@ xmlbuilder@~11.0.0:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
   integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
+xtend@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
# PR #1 Review Notes

## Blocking Issues

1. **TypeScript compiler broken** (`tsconfig.json:5`)
   - Setting `"jsx": "react"` while also specifying `"jsxImportSource": "nativewind"` is invalid. `npx tsc --noEmit` now fails with `TS5089`, so no type checking can run. Switch back to the automatic runtime (`react-jsx`) or drop the global `jsxImportSource`.

2. **Signup flow runs privileged inserts without a session** (`hooks/useAuth.tsx:168-413`)
   - After `supabase.auth.signUp`, the code immediately inserts rows into `companies`, `user_profiles`, `company_members`, etc. When email confirmation is required (the default), `signUp` returns `session = null`, so every PostgREST call executes as the `anon` role and the FK retries never succeed—registration fails outright. You need a service-role API (or defer the inserts until a session exists).

3. **Document upload leaves orphan rows** (`app/(tabs)/(documents)/upload.tsx:235-318`)
   - The screen creates a `documents` record before uploading the file. If `uploadDocumentFile` fails, the catch block only alerts the user; it never deletes the row. Users end up with “pending” documents that can’t be opened. Wrap it in a transaction or delete the document when storage fails.

## Non‑Blocking / Cleanup

4. **Repository contains IDE artifacts** (`.idea/caches/deviceStreaming.xml:1`, other `.idea/*` files)
   - JetBrains cache/config files were committed even though the new `.gitignore` excludes `.idea/`. Remove them to avoid ongoing churn.

5. **Debug log left in production code** (`app/(tabs)/(documents)/upload.tsx:240`)
   - `console.log('employeeId', employeeId);` leaks PII to the JS console. Drop the log before shipping.

## Testing
- `npx tsc --noEmit` → fails with `TS5089` due to the JSX config mismatch.